### PR TITLE
add `MergedIdSegment` to reduce the number of IdSegment creations.

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
     distributor:
       type: redis
     share:
@@ -310,7 +312,7 @@ In actual use, we generally do not use the same `IdGenerator` for all business s
 > Kotlin DSL
 
 ``` kotlin
-    val cosidVersion = "1.3.1";
+    val cosidVersion = "1.3.2";
     implementation("me.ahoo.cosid:spring-boot-starter-cosid:${cosidVersion}")
 ```
 
@@ -326,7 +328,7 @@ In actual use, we generally do not use the same `IdGenerator` for all business s
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosid.version>1.3.1</cosid.version>
+        <cosid.version>1.3.2</cosid.version>
     </properties>
 
     <dependencies>
@@ -386,7 +388,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
     distributor:
       type: redis
     share:
@@ -414,7 +418,7 @@ cosid:
 ``` shell
 gradle cosid-core:jmh
 # or
-java -jar cosid-core/build/libs/cosid-core-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1
+java -jar cosid-core/build/libs/cosid-core-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1
 ```
 
 ```
@@ -435,7 +439,7 @@ SnowflakeIdBenchmark.secondSnowflakeId_generate             thrpt       4206843.
 ``` shell
 gradle cosid-redis:jmh
 # or
-java -jar cosid-redis/build/libs/cosid-redis-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1 RedisChainIdBenchmark
+java -jar cosid-redis/build/libs/cosid-redis-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1 RedisChainIdBenchmark
 ```
 
 ```
@@ -453,7 +457,7 @@ RedisChainIdBenchmark.step_1000            thrpt    5  127439148.104 ±  1833743
 ![RedisChainIdBenchmark-Sample](./docs/jmh/RedisChainIdBenchmark-Sample.png)
 
 ```shell
-java -jar cosid-redis/build/libs/cosid-redis-1.3.1-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
+java -jar cosid-redis/build/libs/cosid-redis-1.3.2-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
 ```
 
 ```
@@ -478,7 +482,7 @@ RedisChainIdBenchmark.step_1000:step_1000·p1.00    sample           37.440     
 ``` shell
 gradle cosid-jdbc:jmh
 # or
-java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1 MySqlChainIdBenchmark
+java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1 MySqlChainIdBenchmark
 ```
 
 ```
@@ -494,7 +498,7 @@ MySqlChainIdBenchmark.step_1000            thrpt    5  123131804.260 ± 1488004.
 ![MySqlChainIdBenchmark-Sample](./docs/jmh/MySqlChainIdBenchmark-Sample.png)
 
 ```shell
-java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.1-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
+java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.2-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
 ```
 ```
 Benchmark                                            Mode      Cnt    Score   Error  Units

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -267,7 +267,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
 ```
 
 ## IdGeneratorProvider
@@ -305,7 +307,7 @@ IdGenerator idGenerator=idGeneratorProvider.get("bizA");
 > Kotlin DSL
 
 ``` kotlin
-    val cosidVersion = "1.3.1";
+    val cosidVersion = "1.3.2";
     implementation("me.ahoo.cosid:spring-boot-starter-cosid:${cosidVersion}")
 ```
 
@@ -321,7 +323,7 @@ IdGenerator idGenerator=idGeneratorProvider.get("bizA");
     <modelVersion>4.0.0</modelVersion>
     <artifactId>demo</artifactId>
     <properties>
-        <cosid.version>1.3.1</cosid.version>
+        <cosid.version>1.3.2</cosid.version>
     </properties>
 
     <dependencies>
@@ -381,7 +383,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
     distributor:
       type: redis
     share:
@@ -407,7 +411,7 @@ cosid:
 ``` shell
 gradle cosid-core:jmh
 # or
-java -jar cosid-core/build/libs/cosid-core-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1
+java -jar cosid-core/build/libs/cosid-core-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1
 ```
 
 ```
@@ -428,7 +432,7 @@ SnowflakeIdBenchmark.secondSnowflakeId_generate             thrpt       4206843.
 ``` shell
 gradle cosid-redis:jmh
 # or
-java -jar cosid-redis/build/libs/cosid-redis-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1 RedisChainIdBenchmark
+java -jar cosid-redis/build/libs/cosid-redis-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1 RedisChainIdBenchmark
 ```
 
 ```
@@ -446,7 +450,7 @@ RedisChainIdBenchmark.step_1000            thrpt    5  127439148.104 ±  1833743
 ![RedisChainIdBenchmark-Sample](./docs/jmh/RedisChainIdBenchmark-Sample.png)
 
 ```shell
-java -jar cosid-redis/build/libs/cosid-redis-1.3.1-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
+java -jar cosid-redis/build/libs/cosid-redis-1.3.2-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
 ```
 
 ```
@@ -471,7 +475,7 @@ RedisChainIdBenchmark.step_1000:step_1000·p1.00    sample           37.440     
 ``` shell
 gradle cosid-jdbc:jmh
 # or
-java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.1-jmh.jar -bm thrpt -wi 1 -rf json -f 1 MySqlChainIdBenchmark
+java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.2-jmh.jar -bm thrpt -wi 1 -rf json -f 1 MySqlChainIdBenchmark
 ```
 
 ```
@@ -487,7 +491,7 @@ MySqlChainIdBenchmark.step_1000            thrpt    5  123131804.260 ± 1488004.
 ![MySqlChainIdBenchmark-Sample](./docs/jmh/MySqlChainIdBenchmark-Sample.png)
 
 ```shell
-java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.1-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
+java -jar cosid-jdbc/build/libs/cosid-jdbc-1.3.2-jmh.jar -bm sample -wi 1 -rf json -f 1 -tu us step_1000
 ```
 ```
 Benchmark                                            Mode      Cnt    Score   Error  Units

--- a/cosid-core/src/jmh/java/me/ahoo/cosid/ClockBenchmark.java
+++ b/cosid-core/src/jmh/java/me/ahoo/cosid/ClockBenchmark.java
@@ -11,25 +11,28 @@
  * limitations under the License.
  */
 
-plugins {
-    id("me.champeau.jmh") version "0.6.4"
-}
+package me.ahoo.cosid;
 
-dependencies {
-    api("com.google.guava:guava")
-    testImplementation("org.junit-pioneer:junit-pioneer")
-    jmh("org.openjdk.jmh:jmh-core:${rootProject.ext.get("jmhVersion")}")
-    jmh("org.openjdk.jmh:jmh-generator-annprocess:${rootProject.ext.get("jmhVersion")}")
-}
+import me.ahoo.cosid.util.Clock;
+import org.openjdk.jmh.annotations.Benchmark;
 
-jmh {
-    jmhVersion.set(rootProject.ext.get("jmhVersion").toString())
-    warmupIterations.set(1)
-    iterations.set(1)
-    resultFormat.set("json")
-    benchmarkMode.set(listOf(
-        "thrpt"
-    ))
-    threads.set(1)
-    fork.set(1)
+/**
+ * @author ahoo wang
+ */
+public class ClockBenchmark {
+
+    @Benchmark
+    public long currentTimeMillis() {
+        return System.currentTimeMillis();
+    }
+
+    @Benchmark
+    public long nanoTime() {
+        return System.nanoTime();
+    }
+
+    @Benchmark
+    public long cacheSecondTime() {
+        return Clock.CACHE.secondTime();
+    }
 }

--- a/cosid-core/src/jmh/java/me/ahoo/cosid/SegmentIdBenchmark.java
+++ b/cosid-core/src/jmh/java/me/ahoo/cosid/SegmentIdBenchmark.java
@@ -13,10 +13,12 @@
 
 package me.ahoo.cosid;
 
+import me.ahoo.cosid.jvm.JdkId;
 import me.ahoo.cosid.segment.DefaultSegmentId;
 import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.SegmentChainId;
 import me.ahoo.cosid.segment.SegmentId;
+import me.ahoo.cosid.segment.concurrent.PrefetchWorkerExecutorService;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -33,11 +35,18 @@ public class SegmentIdBenchmark {
 
     SegmentId segmentId;
     SegmentChainId segmentChainId;
+    JdkId jdkId;
 
     @Setup
     public void setup() {
+        jdkId = new JdkId();
         segmentId = new DefaultSegmentId(new IdSegmentDistributor.Mock());
-        segmentChainId = new SegmentChainId(TIME_TO_LIVE_FOREVER,10, SegmentChainId.DEFAULT_PREFETCH_PERIOD, new IdSegmentDistributor.Mock());
+        segmentChainId = new SegmentChainId(TIME_TO_LIVE_FOREVER, 10000, new IdSegmentDistributor.Mock(), PrefetchWorkerExecutorService.DEFAULT);
+    }
+
+    @Benchmark
+    public long jdkId_generate() {
+        return jdkId.generate();
     }
 
     @Benchmark

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/DefaultIdSegment.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/DefaultIdSegment.java
@@ -13,6 +13,8 @@
 
 package me.ahoo.cosid.segment;
 
+import me.ahoo.cosid.util.Clock;
+
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -27,16 +29,16 @@ public class DefaultIdSegment implements IdSegment {
      */
     private final long maxId;
     private final long offset;
-    private final int step;
+    private final long step;
     private final AtomicLong sequence;
     private final long fetchTime;
     private final long ttl;
 
-    public DefaultIdSegment(long maxId, int step) {
-        this(maxId, step, System.currentTimeMillis(), TIME_TO_LIVE_FOREVER);
+    public DefaultIdSegment(long maxId, long step) {
+        this(maxId, step, Clock.CACHE.secondTime(), TIME_TO_LIVE_FOREVER);
     }
 
-    public DefaultIdSegment(long maxId, int step, long fetchTime, long ttl) {
+    public DefaultIdSegment(long maxId, long step, long fetchTime, long ttl) {
         this.maxId = maxId;
         this.step = step;
         this.offset = maxId - step;
@@ -71,7 +73,7 @@ public class DefaultIdSegment implements IdSegment {
     }
 
     @Override
-    public int getStep() {
+    public long getStep() {
         return step;
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/DefaultSegmentId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/DefaultSegmentId.java
@@ -35,7 +35,7 @@ public class DefaultSegmentId implements SegmentId {
     }
 
     public DefaultSegmentId(long idSegmentTtl, IdSegmentDistributor maxIdDistributor) {
-        Preconditions.checkArgument(idSegmentTtl == TIME_TO_LIVE_FOREVER || idSegmentTtl > 0, Strings.lenientFormat("Illegal idSegmentTtl parameter:[%s].", idSegmentTtl));
+        Preconditions.checkArgument(idSegmentTtl > 0, Strings.lenientFormat("Illegal idSegmentTtl parameter:[%s].", idSegmentTtl));
         this.idSegmentTtl = idSegmentTtl;
         this.maxIdDistributor = maxIdDistributor;
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentChain.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentChain.java
@@ -22,7 +22,7 @@ public class IdSegmentChain implements IdSegment {
     public static final int ROOT_VERSION = -1;
     public static final IdSegmentChain NOT_SET = null;
 
-    private final int version;
+    private final long version;
     private final IdSegment idSegment;
     private volatile IdSegmentChain next;
 
@@ -30,7 +30,7 @@ public class IdSegmentChain implements IdSegment {
         this(previousChain.getVersion() + 1, idSegment);
     }
 
-    public IdSegmentChain(int version, IdSegment idSegment) {
+    public IdSegmentChain(long version, IdSegment idSegment) {
         this.version = version;
         this.idSegment = idSegment;
     }
@@ -71,12 +71,15 @@ public class IdSegmentChain implements IdSegment {
         return idSegment;
     }
 
-    public int getVersion() {
+    public long getVersion() {
         return version;
     }
 
-    public int gap(IdSegmentChain end) {
-        return end.version - version;
+    public int gap(IdSegmentChain end, long step) {
+        if (this.equals(end)) {
+            return 0;
+        }
+        return (int) ((end.getOffset() - getOffset()) / step);
     }
 
     public static IdSegmentChain newRoot() {
@@ -104,7 +107,7 @@ public class IdSegmentChain implements IdSegment {
     }
 
     @Override
-    public int getStep() {
+    public long getStep() {
         return idSegment.getStep();
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/MergedIdSegment.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/MergedIdSegment.java
@@ -13,14 +13,73 @@
 
 package me.ahoo.cosid.segment;
 
+import java.util.concurrent.TimeUnit;
+
 /**
- *
  * @author ahoo wang
  */
-public class MergedIdSegment {
-    private final int segments;
+public class MergedIdSegment implements IdSegment {
 
-    public MergedIdSegment(int segments) {
+    private final int segments;
+    private final IdSegment idSegment;
+    private final long singleStep;
+
+    public MergedIdSegment(int segments, IdSegment idSegment) {
         this.segments = segments;
+        this.idSegment = idSegment;
+        this.singleStep = idSegment.getStep() / segments;
+    }
+
+    public int getSegments() {
+        return segments;
+    }
+
+    public long getSingleStep() {
+        return singleStep;
+    }
+
+    /**
+     * ID segment fetch time
+     * unit {@link TimeUnit#MILLISECONDS}
+     *
+     * @return
+     */
+    @Override
+    public long getFetchTime() {
+        return idSegment.getFetchTime();
+    }
+
+    @Override
+    public long getMaxId() {
+        return idSegment.getMaxId();
+    }
+
+    @Override
+    public long getOffset() {
+        return idSegment.getOffset();
+    }
+
+    @Override
+    public long getSequence() {
+        return idSegment.getSequence();
+    }
+
+    @Override
+    public long getStep() {
+        return idSegment.getStep();
+    }
+
+    @Override
+    public long incrementAndGet() {
+        return idSegment.incrementAndGet();
+    }
+
+    @Override
+    public String toString() {
+        return "MergedIdSegment{" +
+                "segments=" + segments +
+                ", idSegment=" + idSegment +
+                ", singleStep=" + singleStep +
+                '}';
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/AffinityJob.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/AffinityJob.java
@@ -11,25 +11,34 @@
  * limitations under the License.
  */
 
-plugins {
-    id("me.champeau.jmh") version "0.6.4"
-}
+package me.ahoo.cosid.segment.concurrent;
 
-dependencies {
-    api("com.google.guava:guava")
-    testImplementation("org.junit-pioneer:junit-pioneer")
-    jmh("org.openjdk.jmh:jmh-core:${rootProject.ext.get("jmhVersion")}")
-    jmh("org.openjdk.jmh:jmh-generator-annprocess:${rootProject.ext.get("jmhVersion")}")
-}
+import me.ahoo.cosid.util.Clock;
 
-jmh {
-    jmhVersion.set(rootProject.ext.get("jmhVersion").toString())
-    warmupIterations.set(1)
-    iterations.set(1)
-    resultFormat.set("json")
-    benchmarkMode.set(listOf(
-        "thrpt"
-    ))
-    threads.set(1)
-    fork.set(1)
+/**
+ * @author ahoo wang
+ */
+public interface AffinityJob extends Runnable {
+
+    String getJobId();
+
+    default String affinity() {
+        return getJobId();
+    }
+
+    default void hungry() {
+        setHungerTime(Clock.CACHE.secondTime());
+        getPrefetchWorker().wakeup(this);
+    }
+
+    /**
+     *
+     * @param hungerTime {@link java.util.concurrent.TimeUnit#SECONDS}
+     */
+    void setHungerTime(long hungerTime);
+
+    PrefetchWorker getPrefetchWorker();
+
+    void setPrefetchWorker(PrefetchWorker prefetchWorker);
+
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/DefaultPrefetchWorker.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/DefaultPrefetchWorker.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright [2021-2021] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.segment.concurrent;
+
+import com.google.common.base.Strings;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * @author ahoo wang
+ */
+@Slf4j
+public class DefaultPrefetchWorker extends Thread implements PrefetchWorker {
+
+    private static final AtomicInteger THREAD_COUNTER = new AtomicInteger();
+    private volatile boolean shutdown = false;
+    private final Duration prefetchPeriod;
+    private final CopyOnWriteArraySet<AffinityJob> affinityJobs = new CopyOnWriteArraySet<>();
+
+    public DefaultPrefetchWorker(Duration prefetchPeriod) {
+        super(Strings.lenientFormat("DefaultPrefetchWorker-" + THREAD_COUNTER.incrementAndGet()));
+        this.prefetchPeriod = prefetchPeriod;
+    }
+
+    @Override
+    public void shutdown() {
+        if (log.isInfoEnabled()) {
+            log.info("shutdown!");
+        }
+        if (shutdown) {
+            return;
+        }
+        shutdown = true;
+    }
+
+    @Override
+    public void submit(AffinityJob affinityJob) {
+        if (log.isInfoEnabled()) {
+            log.info("submit - [{}] jobSize:[{}].", affinityJob.getJobId(), affinityJobs.size());
+        }
+
+        if (shutdown) {
+            throw new IllegalArgumentException("PrefetchWorker is shutdown.");
+        }
+        affinityJobs.add(affinityJob);
+    }
+
+    @Override
+    public void cancel(AffinityJob affinityJob) {
+        if (log.isInfoEnabled()) {
+            log.info("cancel - [{}] jobSize:[{}].", affinityJob.getJobId(), affinityJobs.size());
+        }
+        affinityJobs.remove(affinityJob);
+    }
+
+    @Override
+    public void wakeup(AffinityJob affinityJob) {
+        if (log.isDebugEnabled()) {
+            log.debug("wakeup - [{}] - state:[{}].", affinityJob.getJobId(), this.getState());
+        }
+        if (shutdown) {
+            if (log.isWarnEnabled()) {
+                log.warn("wakeup - [{}] - PrefetchWorker is shutdown,Can't be awakened!", affinityJob.getJobId());
+            }
+            return;
+        }
+
+        if (State.RUNNABLE.equals(this.getState())) {
+            if (log.isDebugEnabled()) {
+                log.debug("wakeup - [{}] - PrefetchWorker is running ,Don't need to be awakened.", affinityJob.getJobId());
+            }
+            return;
+        }
+        LockSupport.unpark(this);
+    }
+
+    @Override
+    public void run() {
+        while (!shutdown) {
+            try {
+                affinityJobs.forEach(affinityJob -> {
+                    try {
+                        affinityJob.run();
+                    } catch (Throwable throwable) {
+                        if (log.isErrorEnabled()) {
+                            log.error(throwable.getMessage(), throwable);
+                        }
+                    }
+                });
+                LockSupport.parkNanos(this, prefetchPeriod.toNanos());
+            } catch (Throwable throwable) {
+                if (log.isErrorEnabled()) {
+                    log.error(throwable.getMessage(), throwable);
+                }
+            }
+        }
+    }
+}

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/PrefetchWorker.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/PrefetchWorker.java
@@ -11,25 +11,21 @@
  * limitations under the License.
  */
 
-plugins {
-    id("me.champeau.jmh") version "0.6.4"
-}
+package me.ahoo.cosid.segment.concurrent;
 
-dependencies {
-    api("com.google.guava:guava")
-    testImplementation("org.junit-pioneer:junit-pioneer")
-    jmh("org.openjdk.jmh:jmh-core:${rootProject.ext.get("jmhVersion")}")
-    jmh("org.openjdk.jmh:jmh-generator-annprocess:${rootProject.ext.get("jmhVersion")}")
-}
+/**
+ * @author ahoo wang
+ */
+public interface PrefetchWorker {
 
-jmh {
-    jmhVersion.set(rootProject.ext.get("jmhVersion").toString())
-    warmupIterations.set(1)
-    iterations.set(1)
-    resultFormat.set("json")
-    benchmarkMode.set(listOf(
-        "thrpt"
-    ))
-    threads.set(1)
-    fork.set(1)
+    String getName();
+
+    void submit(AffinityJob affinityJob);
+
+    void cancel(AffinityJob affinityJob);
+
+    void wakeup(AffinityJob affinityJob);
+
+    void shutdown();
+
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/PrefetchWorkerExecutorService.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/concurrent/PrefetchWorkerExecutorService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright [2021-2021] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.segment.concurrent;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * @author ahoo wang
+ */
+@Slf4j
+public class PrefetchWorkerExecutorService {
+    public static final Duration DEFAULT_PREFETCH_PERIOD = Duration.ofSeconds(1);
+    public static final PrefetchWorkerExecutorService DEFAULT;
+
+    static {
+        DEFAULT =
+                new PrefetchWorkerExecutorService(DEFAULT_PREFETCH_PERIOD, Runtime.getRuntime().availableProcessors());
+    }
+
+    private volatile boolean shutdown = false;
+    private final int corePoolSize;
+    private final Duration prefetchPeriod;
+    private final DefaultPrefetchWorker[] workers;
+    private boolean initialized = false;
+    private final AtomicLong threadIdx = new AtomicLong();
+
+    public PrefetchWorkerExecutorService(Duration prefetchPeriod, int corePoolSize) {
+        this.prefetchPeriod = prefetchPeriod;
+        this.corePoolSize = corePoolSize;
+        this.workers = new DefaultPrefetchWorker[corePoolSize];
+        Runtime.getRuntime().addShutdownHook(new GracefullyCloser());
+    }
+
+    private void ensureInitWorkers() {
+        if (initialized) {
+            return;
+        }
+        initialized = true;
+        for (int i = 0; i < corePoolSize; i++) {
+            final DefaultPrefetchWorker prefetchWorker = new DefaultPrefetchWorker(prefetchPeriod);
+            prefetchWorker.setDaemon(true);
+            workers[i] = prefetchWorker;
+            if (log.isDebugEnabled()) {
+                log.debug("initWorkers - [{}].", prefetchWorker.getName());
+            }
+        }
+    }
+
+    public void shutdown() {
+        if (log.isInfoEnabled()) {
+            log.info("shutdown!");
+        }
+        if (shutdown) {
+            return;
+        }
+        shutdown = true;
+
+        for (DefaultPrefetchWorker worker : workers) {
+            if (worker != null) {
+                worker.shutdown();
+            }
+        }
+    }
+
+    public void submit(AffinityJob affinityJob) {
+        if (log.isInfoEnabled()) {
+            log.info("submit - jobId:[{}].", affinityJob.getJobId());
+        }
+        if (shutdown) {
+            throw new IllegalArgumentException("PrefetchWorkerExecutorService is shutdown.");
+        }
+        if (affinityJob.getPrefetchWorker() != null) {
+            return;
+        }
+        synchronized (this) {
+            if (affinityJob.getPrefetchWorker() != null) {
+                return;
+            }
+            ensureInitWorkers();
+            DefaultPrefetchWorker prefetchWorker = chooseWorker();
+            if (log.isInfoEnabled()) {
+                log.info("submit - jobId:[{}] is bound to thread:[{}].", affinityJob.getJobId(), prefetchWorker.getName());
+            }
+
+            if (Thread.State.NEW.equals(prefetchWorker.getState())) {
+                if (log.isInfoEnabled()) {
+                    log.info("submit - jobId:[{}] is bound to thread:[{}] start.", affinityJob.getJobId(), prefetchWorker.getName());
+                }
+                prefetchWorker.start();
+            }
+            prefetchWorker.submit(affinityJob);
+            affinityJob.setPrefetchWorker(prefetchWorker);
+        }
+    }
+
+    private DefaultPrefetchWorker chooseWorker() {
+        return workers[(int) Math.abs(threadIdx.getAndIncrement() % workers.length)];
+    }
+
+    public class GracefullyCloser extends Thread {
+        @Override
+        public void run() {
+            if (log.isInfoEnabled()){
+                log.info("Close gracefully!");
+            }
+            shutdown();
+        }
+    }
+}

--- a/cosid-core/src/main/java/me/ahoo/cosid/util/Clock.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/util/Clock.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright [2021-2021] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.util;
+
+import java.time.Duration;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * {@link System#currentTimeMillis()} is too slow!
+ *
+ * @author ahoo wang
+ */
+public interface Clock {
+
+    Clock CACHE = new CacheClock();
+    Clock SYSTEM = new SystemClock();
+
+    long secondTime();
+
+    static long getSystemSecondTime() {
+        return System.currentTimeMillis() / 1000;
+    }
+
+    class SystemClock implements Clock {
+
+        /**
+         * {@link System#currentTimeMillis()} is too slow!
+         *
+         * @return
+         */
+        @Override
+        public long secondTime() {
+            return getSystemSecondTime();
+        }
+    }
+
+    /**
+     * Fix the problem that {@link System#currentTimeMillis()} is too slow
+     * The accuracy is 1 second
+     *
+     * @author ahoo wang
+     */
+    class CacheClock implements Clock, Runnable {
+        /**
+         * Tolerate a one-second time limit
+         */
+        public static final long ONE_SECOND_PERIOD = Duration.ofSeconds(1).toNanos();
+        private final Thread thread;
+        private volatile long lastTime;
+
+        public CacheClock() {
+            this.lastTime = getSystemSecondTime();
+            this.thread = new Thread(this);
+            this.thread.setName("CosId-CacheClock");
+            this.thread.setDaemon(true);
+            this.thread.start();
+        }
+
+        @Override
+        public long secondTime() {
+            return lastTime;
+        }
+
+        /**
+         * When an object implementing interface <code>Runnable</code> is used
+         * to create a thread, starting the thread causes the object's
+         * <code>run</code> method to be called in that separately executing
+         * thread.
+         * <p>
+         * The general contract of the method <code>run</code> is that it may
+         * take any action whatsoever.
+         *
+         * @see Thread#run()
+         */
+        @Override
+        public void run() {
+            while (true) {
+                this.lastTime = getSystemSecondTime();
+                LockSupport.parkNanos(this, ONE_SECOND_PERIOD);
+            }
+        }
+    }
+}

--- a/cosid-core/src/test/java/me/ahoo/cosid/util/ClockTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/util/ClockTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright [2021-2021] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.util;
+
+import com.google.common.base.Strings;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.concurrent.locks.LockSupport;
+
+/**
+ * @author ahoo wang
+ */
+public class ClockTest {
+
+//    @Test
+    public void cacheClock() {
+        final long MAX_TRY_TIMES = 1000;
+        final long parkNanos = Duration.ofMillis(100).toNanos();
+        int currentTimes = 0;
+        int diffTimes = 0;
+
+        while (currentTimes < MAX_TRY_TIMES) {
+            currentTimes++;
+            long cacheSecond = Clock.CACHE.secondTime();
+            long systemSecond = Clock.getSystemSecondTime();
+            long diff = systemSecond - cacheSecond;
+            if (diff != 0) {
+                diffTimes++;
+            }
+            System.out.println(Strings.lenientFormat("cacheTime:[%s] - systemTime:[%s] - diff:[%s] - diffTimes:[%s]", cacheSecond, systemSecond, diff, diffTimes));
+            Assertions.assertTrue(diff <= 1);
+            LockSupport.parkNanos(this, parkNanos);
+        }
+
+    }
+}

--- a/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributor.java
+++ b/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributor.java
@@ -36,16 +36,16 @@ public class JdbcIdSegmentDistributor implements IdSegmentDistributor {
 
     private final String namespace;
     private final String name;
-    private final int step;
+    private final long step;
     private final DataSource dataSource;
     private final String incrementMaxIdSql;
     private final String fetchMaxIdSql;
 
-    public JdbcIdSegmentDistributor(String namespace, String name, int step, DataSource dataSource) {
+    public JdbcIdSegmentDistributor(String namespace, String name, long step, DataSource dataSource) {
         this(namespace, name, step, INCREMENT_MAX_ID_SQL, FETCH_MAX_ID_SQL, dataSource);
     }
 
-    public JdbcIdSegmentDistributor(String namespace, String name, int step, String incrementMaxIdSql, String fetchMaxIdSql, DataSource dataSource) {
+    public JdbcIdSegmentDistributor(String namespace, String name, long step, String incrementMaxIdSql, String fetchMaxIdSql, DataSource dataSource) {
         this.namespace = namespace;
         this.name = name;
         this.step = step;
@@ -65,17 +65,18 @@ public class JdbcIdSegmentDistributor implements IdSegmentDistributor {
     }
 
     @Override
-    public int getStep() {
+    public long getStep() {
         return step;
     }
 
 
     @Override
-    public long nextMaxId(int step) {
+    public long nextMaxId(long step) {
+        IdSegmentDistributor.ensureStep(step);
         try (Connection connection = dataSource.getConnection()) {
             connection.setAutoCommit(false);
             try (PreparedStatement accStatement = connection.prepareStatement(incrementMaxIdSql)) {
-                accStatement.setInt(1, step);
+                accStatement.setLong(1, step);
                 accStatement.setString(2, getNamespacedName());
                 int affected = accStatement.executeUpdate();
                 if (affected == 0) {

--- a/cosid-redis/src/main/java/me/ahoo/cosid/redis/RedisIdSegmentDistributor.java
+++ b/cosid-redis/src/main/java/me/ahoo/cosid/redis/RedisIdSegmentDistributor.java
@@ -42,8 +42,8 @@ public class RedisIdSegmentDistributor implements IdSegmentDistributor {
      * cosid:{namespace.name}:adder
      */
     private final String adderKey;
-    private final int offset;
-    private final int step;
+    private final long offset;
+    private final long step;
     private final Duration timeout;
     private final RedisClusterAsyncCommands<String, String> redisCommands;
 
@@ -55,8 +55,8 @@ public class RedisIdSegmentDistributor implements IdSegmentDistributor {
 
     public RedisIdSegmentDistributor(String namespace,
                                      String name,
-                                     int offset,
-                                     int step,
+                                     long offset,
+                                     long step,
                                      Duration timeout,
                                      RedisClusterAsyncCommands<String, String> redisCommands) {
         this.step = step;
@@ -76,25 +76,26 @@ public class RedisIdSegmentDistributor implements IdSegmentDistributor {
         return name;
     }
 
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
     @Override
-    public int getStep() {
+    public long getStep() {
         return step;
     }
 
     @Override
-    public long nextMaxId(int step) {
+    public long nextMaxId(long step) {
+        IdSegmentDistributor.ensureStep(step);
         long maxId = Futures.getUnChecked(fetchMaxIdAsync(step), timeout);
-        if (log.isDebugEnabled()) {
-            log.debug("nextMaxId - step:[{}] - maxId:[{}].", step, maxId);
+        if (log.isInfoEnabled()) {
+            log.info("nextMaxId - step:[{}] - maxId:[{}].", step, maxId);
         }
         return maxId;
     }
 
-    private CompletableFuture<Long> fetchMaxIdAsync(int step) {
+    private CompletableFuture<Long> fetchMaxIdAsync(long step) {
         return RedisScripts.doEnsureScript(REDIS_ID_GENERATE, redisCommands,
                 (scriptSha) -> {
                     String[] keys = {adderKey};

--- a/cosid-rest-api/src/dist/config/application.yaml
+++ b/cosid-rest-api/src/dist/config/application.yaml
@@ -33,7 +33,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
     distributor:
       type: redis
     share:

--- a/cosid-rest-api/src/main/resources/application.yaml
+++ b/cosid-rest-api/src/main/resources/application.yaml
@@ -41,7 +41,9 @@ cosid:
     mode: chain
     chain:
       safe-distance: 5
-      prefetch-period: 1s
+      prefetch-worker:
+        core-pool-size: 2
+        prefetch-period: 1s
     distributor:
       type: redis
     share:

--- a/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributor.java
+++ b/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributor.java
@@ -42,8 +42,8 @@ public class SpringRedisIdSegmentDistributor implements IdSegmentDistributor {
      * cosid:{namespace.name}:adder
      */
     private final String adderKey;
-    private final int offset;
-    private final int step;
+    private final long offset;
+    private final long step;
     private final StringRedisTemplate redisTemplate;
 
     public SpringRedisIdSegmentDistributor(String namespace,
@@ -54,8 +54,8 @@ public class SpringRedisIdSegmentDistributor implements IdSegmentDistributor {
 
     public SpringRedisIdSegmentDistributor(String namespace,
                                            String name,
-                                           int offset,
-                                           int step,
+                                           long offset,
+                                           long step,
                                            StringRedisTemplate redisTemplate) {
         this.step = step;
         this.namespace = namespace;
@@ -73,17 +73,18 @@ public class SpringRedisIdSegmentDistributor implements IdSegmentDistributor {
         return name;
     }
 
-    public int getOffset() {
+    public long getOffset() {
         return offset;
     }
 
     @Override
-    public int getStep() {
+    public long getStep() {
         return step;
     }
 
     @Override
-    public long nextMaxId(int step) {
+    public long nextMaxId(long step) {
+        IdSegmentDistributor.ensureStep(step);
         List<String> keys = Collections.singletonList(adderKey);
         String[] values = {String.valueOf(offset), String.valueOf(step)};
         long maxId = redisTemplate.execute(REDIS_ID_GENERATE, keys, values);

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@
 #
 
 group=me.ahoo.cosid
-version=1.3.1
+version=1.3.2
 
 description=Global distributed ID generator
 website=https://github.com/Ahoo-Wang/CosId

--- a/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdLifecyclePrefetchWorkerExecutorService.java
+++ b/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdLifecyclePrefetchWorkerExecutorService.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid.spring.boot.starter.segment;
 
 import lombok.extern.slf4j.Slf4j;
-import me.ahoo.cosid.provider.IdGeneratorProvider;
+import me.ahoo.cosid.segment.concurrent.PrefetchWorkerExecutorService;
 import org.springframework.beans.factory.DisposableBean;
 import org.springframework.context.SmartLifecycle;
 
@@ -22,12 +22,12 @@ import org.springframework.context.SmartLifecycle;
  * @author ahoo wang
  */
 @Slf4j
-public class CosIdLifecycleSegmentChainId implements SmartLifecycle {
+public class CosIdLifecyclePrefetchWorkerExecutorService implements SmartLifecycle {
     private volatile boolean running;
-    private final IdGeneratorProvider idGeneratorProvider;
+    private final PrefetchWorkerExecutorService prefetchWorkerExecutorService;
 
-    public CosIdLifecycleSegmentChainId(IdGeneratorProvider idGeneratorProvider) {
-        this.idGeneratorProvider = idGeneratorProvider;
+    public CosIdLifecyclePrefetchWorkerExecutorService(PrefetchWorkerExecutorService prefetchWorkerExecutorService) {
+        this.prefetchWorkerExecutorService = prefetchWorkerExecutorService;
     }
 
     /**
@@ -65,15 +65,7 @@ public class CosIdLifecycleSegmentChainId implements SmartLifecycle {
             return;
         }
         running = false;
-        idGeneratorProvider.getAll().stream().filter(idGenerator -> idGenerator instanceof AutoCloseable).map(idGenerator -> (AutoCloseable) idGenerator).forEach(autoCloseable -> {
-            try {
-                autoCloseable.close();
-            } catch (Exception exception) {
-                if (log.isErrorEnabled()) {
-                    log.error(exception.getMessage(), exception);
-                }
-            }
-        });
+        prefetchWorkerExecutorService.shutdown();
     }
 
     /**

--- a/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/ConditionalOnCosIdSnowflakeEnabled.java
+++ b/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/ConditionalOnCosIdSnowflakeEnabled.java
@@ -26,7 +26,7 @@ import java.lang.annotation.Target;
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.TYPE, ElementType.METHOD})
-@ConditionalOnProperty(value = ConditionalOnCosIdSnowflakeEnabled.ENABLED_KEY, matchIfMissing = true, havingValue = "true")
+@ConditionalOnProperty(value = ConditionalOnCosIdSnowflakeEnabled.ENABLED_KEY, matchIfMissing = false, havingValue = "true")
 public @interface ConditionalOnCosIdSnowflakeEnabled {
     String ENABLED_KEY = SnowflakeIdProperties.PREFIX + EnabledSuffix.KEY;
 }

--- a/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdProperties.java
+++ b/spring-boot-starter-cosid/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdProperties.java
@@ -29,7 +29,7 @@ import java.util.Map;
 public class SnowflakeIdProperties {
     public final static String PREFIX = CosId.COSID_PREFIX + "snowflake";
 
-    private boolean enabled;
+    private boolean enabled = false;
     private long epoch = CosId.COSID_EPOCH;
     private Machine machine;
     private ClockBackwards clockBackwards;


### PR DESCRIPTION
add `PrefetchWorkerExecutorService` to improve thread utilization of `PrefetchWorker`.
Optimize performance, use `CacheClock` to replace `System#currentTimeMillis`(too slow!)  implementation .
enhance: Numerical overflow check