### PR TITLE
feat: Support for easier configuration of custom ID converters.

### DIFF
--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDecorator.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDecorator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.spring.boot.starter;
+
+import me.ahoo.cosid.IdConverter;
+import me.ahoo.cosid.IdGenerator;
+import me.ahoo.cosid.converter.PrefixIdConverter;
+import me.ahoo.cosid.converter.Radix62IdConverter;
+import me.ahoo.cosid.converter.SuffixIdConverter;
+import me.ahoo.cosid.converter.ToStringIdConverter;
+
+import com.google.common.base.Strings;
+
+import java.lang.reflect.InvocationTargetException;
+
+public abstract class IdConverterDecorator<T extends IdGenerator> {
+    protected final T idGenerator;
+    protected final IdConverterDefinition converterDefinition;
+    
+    protected IdConverterDecorator(T idGenerator, IdConverterDefinition converterDefinition) {
+        this.idGenerator = idGenerator;
+        this.converterDefinition = converterDefinition;
+    }
+    
+    public T decorate() {
+        IdConverter idConverter = ToStringIdConverter.INSTANCE;
+        switch (converterDefinition.getType()) {
+            case TO_STRING -> idConverter = newToString(idConverter);
+            case RADIX -> idConverter = newRadix();
+            case SNOWFLAKE_FRIENDLY -> idConverter = newSnowflakeFriendly();
+            case CUSTOM -> idConverter = newCustom();
+            default -> throw new IllegalStateException("Unexpected value: " + converterDefinition.getType());
+        }
+        
+        if (!Strings.isNullOrEmpty(converterDefinition.getPrefix())) {
+            idConverter = new PrefixIdConverter(converterDefinition.getPrefix(), idConverter);
+        }
+        if (!Strings.isNullOrEmpty(converterDefinition.getSuffix())) {
+            idConverter = new SuffixIdConverter(converterDefinition.getSuffix(), idConverter);
+        }
+        
+        return newIdGenerator(idConverter);
+    }
+    
+    protected IdConverter newRadix() {
+        IdConverterDefinition.Radix radix = converterDefinition.getRadix();
+        return Radix62IdConverter.of(radix.isPadStart(), radix.getCharSize());
+    }
+    
+    protected IdConverter newToString(IdConverter defaultIdConverter) {
+        IdConverterDefinition.ToString toString = converterDefinition.getToString();
+        if (toString != null) {
+            return new ToStringIdConverter(toString.isPadStart(), toString.getCharSize());
+        }
+        return defaultIdConverter;
+    }
+    
+    protected IdConverter newSnowflakeFriendly() {
+        throw new UnsupportedOperationException("newSnowflakeFriendly");
+    }
+    
+    protected IdConverter newCustom() {
+        IdConverterDefinition.Custom custom = converterDefinition.getCustom();
+        try {
+            return custom.getType().getConstructor().newInstance();
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    
+    protected abstract T newIdGenerator(IdConverter idConverter);
+}

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDefinition.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDefinition.java
@@ -136,8 +136,9 @@ public class IdConverterDefinition {
             return type;
         }
         
-        public void setType(Class<? extends IdConverter> type) {
+        public Custom setType(Class<? extends IdConverter> type) {
             this.type = type;
+            return this;
         }
     }
     

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDefinition.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/IdConverterDefinition.java
@@ -13,6 +13,7 @@
 
 package me.ahoo.cosid.spring.boot.starter;
 
+import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.converter.Radix62IdConverter;
 
 /**
@@ -27,6 +28,7 @@ public class IdConverterDefinition {
     private String suffix;
     private Radix radix = new Radix();
     private ToString toString;
+    private Custom custom;
     
     public Type getType() {
         return type;
@@ -66,6 +68,14 @@ public class IdConverterDefinition {
     
     public void setToString(ToString toString) {
         this.toString = toString;
+    }
+    
+    public Custom getCustom() {
+        return custom;
+    }
+    
+    public void setCustom(Custom custom) {
+        this.custom = custom;
     }
     
     /**
@@ -119,13 +129,26 @@ public class IdConverterDefinition {
         }
     }
     
+    public static class Custom {
+        private Class<? extends IdConverter> type;
+        
+        public Class<? extends IdConverter> getType() {
+            return type;
+        }
+        
+        public void setType(Class<? extends IdConverter> type) {
+            this.type = type;
+        }
+    }
+    
     /**
      * IdConverter Type.
      */
     public enum Type {
         TO_STRING,
         SNOWFLAKE_FRIENDLY,
-        RADIX
+        RADIX,
+        CUSTOM
     }
     
     interface PadStartIdConverter {

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdBeanRegistrar.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdBeanRegistrar.java
@@ -13,11 +13,6 @@
 
 package me.ahoo.cosid.spring.boot.starter.segment;
 
-import me.ahoo.cosid.IdConverter;
-import me.ahoo.cosid.converter.PrefixIdConverter;
-import me.ahoo.cosid.converter.Radix62IdConverter;
-import me.ahoo.cosid.converter.SuffixIdConverter;
-import me.ahoo.cosid.converter.ToStringIdConverter;
 import me.ahoo.cosid.provider.IdGeneratorProvider;
 import me.ahoo.cosid.segment.DefaultSegmentId;
 import me.ahoo.cosid.segment.IdSegmentDistributor;
@@ -25,14 +20,12 @@ import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 import me.ahoo.cosid.segment.SegmentChainId;
 import me.ahoo.cosid.segment.SegmentId;
-import me.ahoo.cosid.segment.StringSegmentId;
 import me.ahoo.cosid.segment.concurrent.PrefetchWorkerExecutorService;
 import me.ahoo.cosid.spring.boot.starter.CosIdProperties;
 import me.ahoo.cosid.spring.boot.starter.IdConverterDefinition;
 import me.ahoo.cosid.spring.boot.starter.Namespaces;
 
 import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -108,34 +101,7 @@ public class SegmentIdBeanRegistrar implements InitializingBean {
         }
         
         IdConverterDefinition converterDefinition = idDefinition.getConverter();
-        
-        IdConverter idConverter = ToStringIdConverter.INSTANCE;
-        switch (converterDefinition.getType()) {
-            case TO_STRING: {
-                IdConverterDefinition.ToString toString = converterDefinition.getToString();
-                if (toString != null) {
-                    idConverter = new ToStringIdConverter(toString.isPadStart(), toString.getCharSize());
-                }
-                break;
-            }
-            case RADIX: {
-                IdConverterDefinition.Radix radix = converterDefinition.getRadix();
-                idConverter = Radix62IdConverter.of(radix.isPadStart(), radix.getCharSize());
-                break;
-            }
-            default:
-                throw new IllegalStateException("Unexpected value: " + converterDefinition.getType());
-        }
-        
-        if (!Strings.isNullOrEmpty(converterDefinition.getPrefix())) {
-            idConverter = new PrefixIdConverter(converterDefinition.getPrefix(), idConverter);
-        }
-        if (!Strings.isNullOrEmpty(converterDefinition.getSuffix())) {
-            idConverter = new SuffixIdConverter(converterDefinition.getSuffix(), idConverter);
-        }
-        return new StringSegmentId(segmentId, idConverter);
-        
+        return new SegmentIdConverterDecorator(segmentId, converterDefinition).decorate();
     }
-    
     
 }

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdConverterDecorator.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdConverterDecorator.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.spring.boot.starter.segment;
+
+import me.ahoo.cosid.IdConverter;
+import me.ahoo.cosid.segment.SegmentId;
+import me.ahoo.cosid.segment.StringSegmentId;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDecorator;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDefinition;
+
+public class SegmentIdConverterDecorator extends IdConverterDecorator<SegmentId> {
+    protected SegmentIdConverterDecorator(SegmentId idGenerator, IdConverterDefinition converterDefinition) {
+        super(idGenerator, converterDefinition);
+    }
+    
+    @Override
+    protected SegmentId newIdGenerator(IdConverter idConverter) {
+        return new StringSegmentId(idGenerator, idConverter);
+    }
+}

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdBeanRegistrar.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdBeanRegistrar.java
@@ -61,7 +61,7 @@ public class SnowflakeIdBeanRegistrar implements InitializingBean {
     }
     
     @Override
-    public void afterPropertiesSet() throws Exception {
+    public void afterPropertiesSet() {
         register();
     }
     

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdConverterDecorator.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdConverterDecorator.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.spring.boot.starter.snowflake;
+
+import me.ahoo.cosid.IdConverter;
+import me.ahoo.cosid.converter.SnowflakeFriendlyIdConverter;
+import me.ahoo.cosid.snowflake.DefaultSnowflakeFriendlyId;
+import me.ahoo.cosid.snowflake.SnowflakeId;
+import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
+import me.ahoo.cosid.snowflake.StringSnowflakeId;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDecorator;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDefinition;
+
+import java.time.ZoneId;
+
+public class SnowflakeIdConverterDecorator extends IdConverterDecorator<SnowflakeId> {
+    private final ZoneId zoneId;
+    private final boolean isFriendly;
+    
+    protected SnowflakeIdConverterDecorator(SnowflakeId idGenerator, IdConverterDefinition converterDefinition, ZoneId zoneId, boolean isFriendly) {
+        super(idGenerator, converterDefinition);
+        this.zoneId = zoneId;
+        this.isFriendly = isFriendly;
+    }
+    
+    @Override
+    protected IdConverter newSnowflakeFriendly() {
+        return new SnowflakeFriendlyIdConverter(SnowflakeIdStateParser.of(idGenerator, zoneId));
+    }
+    
+    @Override
+    protected SnowflakeId newIdGenerator(IdConverter idConverter) {
+        if (isFriendly) {
+            SnowflakeIdStateParser snowflakeIdStateParser = SnowflakeIdStateParser.of(idGenerator, zoneId);
+            return new DefaultSnowflakeFriendlyId(idGenerator, idConverter, snowflakeIdStateParser);
+        }
+        return new StringSnowflakeId(idGenerator, idConverter);
+    }
+}

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdConverterDecoratorTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/SegmentIdConverterDecoratorTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.spring.boot.starter.segment;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import me.ahoo.cosid.IdConverter;
+import me.ahoo.cosid.converter.SuffixIdConverter;
+import me.ahoo.cosid.segment.DefaultSegmentId;
+import me.ahoo.cosid.segment.IdSegmentDistributor;
+import me.ahoo.cosid.segment.SegmentId;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDefinition;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.annotation.Nonnull;
+
+public class SegmentIdConverterDecoratorTest {
+    @Test
+    void newSnowflakeFriendly() {
+        IdConverterDefinition idConverterDefinition = new IdConverterDefinition();
+        idConverterDefinition.setType(IdConverterDefinition.Type.SNOWFLAKE_FRIENDLY);
+        SegmentId segmentId = new DefaultSegmentId(new IdSegmentDistributor.Mock());
+        Assertions.assertThrows(UnsupportedOperationException.class,
+            () -> new SegmentIdConverterDecorator(segmentId, idConverterDefinition).decorate()
+        );
+    }
+    
+    @Test
+    void newCustom() {
+        IdConverterDefinition idConverterDefinition = new IdConverterDefinition();
+        idConverterDefinition.setType(IdConverterDefinition.Type.CUSTOM);
+        idConverterDefinition.setCustom(new IdConverterDefinition.Custom().setType(SegmentIdConverterDecoratorTest.CustomIdConverter.class));
+        SegmentId segmentId = new DefaultSegmentId(new IdSegmentDistributor.Mock());
+        SegmentId newIdGen = new SegmentIdConverterDecorator(segmentId, idConverterDefinition).decorate();
+        assertThat(newIdGen.idConverter(), instanceOf(SegmentIdConverterDecoratorTest.CustomIdConverter.class));
+    }
+    
+    
+    @Test
+    void withPrefixAndSuffix() {
+        IdConverterDefinition idConverterDefinition = new IdConverterDefinition();
+        idConverterDefinition.setPrefix("prefix-");
+        idConverterDefinition.setSuffix("suffix-");
+        SegmentId segmentId = new DefaultSegmentId(new IdSegmentDistributor.Mock());
+        SegmentId newIdGen = new SegmentIdConverterDecorator(segmentId, idConverterDefinition).decorate();
+        assertThat(newIdGen.idConverter(), instanceOf(SuffixIdConverter.class));
+    }
+    
+    public static class CustomIdConverter implements IdConverter {
+        @Nonnull
+        @Override
+        public String asString(long id) {
+            return String.valueOf(id);
+        }
+        
+        @Override
+        public long asLong(@Nonnull String idString) {
+            return Long.getLong(idString);
+        }
+    }
+}
+

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdConverterDecoratorTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/snowflake/SnowflakeIdConverterDecoratorTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.spring.boot.starter.snowflake;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+import me.ahoo.cosid.converter.SnowflakeFriendlyIdConverter;
+import me.ahoo.cosid.snowflake.MillisecondSnowflakeId;
+import me.ahoo.cosid.snowflake.SnowflakeId;
+import me.ahoo.cosid.spring.boot.starter.IdConverterDefinition;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.ZoneId;
+
+class SnowflakeIdConverterDecoratorTest {
+    
+    @Test
+    void newSnowflakeFriendly() {
+        IdConverterDefinition idConverterDefinition = new IdConverterDefinition();
+        idConverterDefinition.setType(IdConverterDefinition.Type.SNOWFLAKE_FRIENDLY);
+        SnowflakeId snowflakeId = new MillisecondSnowflakeId(1);
+        SnowflakeId newIdGen = new SnowflakeIdConverterDecorator(snowflakeId, idConverterDefinition, ZoneId.systemDefault(), false).decorate();
+        assertThat(newIdGen.idConverter(), instanceOf(SnowflakeFriendlyIdConverter.class));
+    }
+}

--- a/examples/cosid-example-redis/src/main/java/me/ahoo/cosid/example/redis/controller/CustomIdConverter.java
+++ b/examples/cosid-example-redis/src/main/java/me/ahoo/cosid/example/redis/controller/CustomIdConverter.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.example.redis.controller;
+
+import me.ahoo.cosid.IdConverter;
+
+import javax.annotation.Nonnull;
+
+public class CustomIdConverter implements IdConverter {
+    @Nonnull
+    @Override
+    public String asString(long id) {
+        return String.valueOf(id);
+    }
+    
+    @Override
+    public long asLong(@Nonnull String idString) {
+        return Long.getLong(idString);
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,14 +10,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
 group=me.ahoo.cosid
-version=2.1.1
-
+version=2.1.2
 description=Universal, flexible, high-performance distributed ID generator.
 website=https://github.com/Ahoo-Wang/CosId
 issues=https://github.com/Ahoo-Wang/CosId/issues
 vcs=https://github.com/Ahoo-Wang/CosId.git
-
 license_name=The Apache Software License, Version 2.0
 license_url=https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION

Changes proposed in this pull request:
- feat: Support for easier configuration of custom ID converters.
``` yaml
      converter:
        type: custom
        custom:
          type: me.ahoo.cosid.example.redis.controller.CustomIdConverter

```


