### PR TITLE
deps: Update SpringBoot to 3.2.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -138,6 +138,11 @@ configure(libraryProjects) {
         }
     }
 
+    // SpringBoot 3.2.0: fix Failed to extract parameter names for CosIdEndpoint
+    tasks.withType<JavaCompile> {
+        options.compilerArgs.addAll(listOf("-parameters"))
+    }
+
     dependencies {
         api(platform(dependenciesProject))
         annotationProcessor(platform(dependenciesProject))

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@
 # limitations under the License.
 #
 group=me.ahoo.cosid
-version=2.5.6
+version=2.6.0
 description=Universal, flexible, high-performance distributed ID generator.
 website=https://github.com/Ahoo-Wang/CosId
 issues=https://github.com/Ahoo-Wang/CosId/issues

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # libraries
-springBoot = "3.1.5"
+springBoot = "3.2.0"
 springCloud = "2022.0.4"
 okhttp = "4.12.0"
 testcontainers = "1.19.3"


### PR DESCRIPTION
Changes proposed in this pull request:
- Update SpringBoot to 3.2.0
- Adapt SpringBoot to 3.2.0

```kotlin
    // SpringBoot 3.2.0: fix Failed to extract parameter names for CosIdEndpoint
    tasks.withType<JavaCompile> {
        options.compilerArgs.addAll(listOf("-parameters"))
    }
```