### PR TITLE
ci: update workflow configurations

### DIFF
--- a/.github/workflows/benchmark-test.yml
+++ b/.github/workflows/benchmark-test.yml
@@ -28,11 +28,6 @@ on:
       - 'cosid-core/**'
       - 'cosid-spring-redis/**'
       - 'cosid-jdbc/**'
-  pull_request:
-    paths:
-      - 'cosid-core/**'
-      - 'cosid-spring-redis/**'
-      - 'cosid-jdbc/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/document-deploy.yml
+++ b/.github/workflows/document-deploy.yml
@@ -16,9 +16,6 @@ on:
   push:
     paths:
       - 'documentation/**'
-  pull_request:
-    paths:
-      - 'documentation/**'
   workflow_dispatch:
 permissions:
   contents: write

--- a/.github/workflows/example-test.yml
+++ b/.github/workflows/example-test.yml
@@ -13,9 +13,6 @@
 
 name: Example Test
 on:
-  push:
-    paths:
-      - 'examples/**'
   pull_request:
     paths:
       - 'examples/**'

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -13,14 +13,6 @@
 
 name: Integration Test
 on:
-  push:
-    paths-ignore:
-      - 'cosid-benchmark/**'
-      - 'docs/**'
-      - 'document/**'
-      - 'documentation/**'
-      - 'examples/**'
-      - 'wiki/**'
   pull_request:
     paths-ignore:
       - 'cosid-benchmark/**'
@@ -229,7 +221,7 @@ jobs:
           settings-path: ${{ github.workspace }}
 
       - name: Test CosId-Proxy
-        run: ./gradlew cosid-proxy:clean cosid-proxy:check
+        run: ./gradlew cosid-proxy:clean cosid-proxy:check --stacktrace
 
   cosid-zookeeper-test:
     name: CosId Zookeeper Test


### PR DESCRIPTION
- Remove unnecessary pull_request paths for benchmark-test, document-deploy, and example-test workflows
- Add --stacktrace flag to cosid-proxy test command in integration-test workflow
- Simplify integration-test workflow triggers

