### PR TITLE
chore(docs): update GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/document-deploy.yml
+++ b/.github/workflows/document-deploy.yml
@@ -45,6 +45,9 @@ jobs:
           server-id: github
           settings-path: ${{ github.workspace }}
 
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
       - name: Generate JavaDoc
         run: ./gradlew aggregateJavadoc
 


### PR DESCRIPTION
- Replace `crazy-max/ghaction-github-pages` with `actions/upload-pages-artifact` and `actions/deploy-pages`
- Remove unused environment variables and FQDN configuration
- Simplify deployment steps by removing commented-out code
- Update artifact upload path to use relative directory
- Remove Gitee sync step and related SSH key configuration
- Enable standard GitHub Pages deployment action with explicit ID
