### PR TITLE
chore: ignore all build dir and .vscode for vscode(ie:codespace)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 .gradle
-/build/
+build/
 
 # Ignore Gradle GUI config
 gradle-app.setting
@@ -13,3 +13,7 @@ gradle-app.setting
 # # Work around https://youtrack.jetbrains.com/issue/IDEA-116898
 # gradle/wrapper/gradle-wrapper.properties
 /cosid-benchmark/.idea/**
+
+# vscode
+.vscode
+


### PR DESCRIPTION
Fixes #ISSUSE_ID.

Changes proposed in this pull request:
-
-
-
