### PR TITLE
chore(docs): update mermaid and vitepress dependencies

### DIFF
--- a/documentation/package.json
+++ b/documentation/package.json
@@ -12,8 +12,8 @@
   "author": "ahoo wang",
   "license": "Apache 2.0",
   "devDependencies": {
-    "mermaid": "^11.4.1",
-    "vitepress": "^1.5.0",
+    "mermaid": "^11.12.1",
+    "vitepress": "^1.6.4",
     "vitepress-plugin-mermaid": "^2.0.17"
   },
   "dependencies": {

--- a/documentation/pnpm-lock.yaml
+++ b/documentation/pnpm-lock.yaml
@@ -13,10 +13,10 @@ importers:
         version: 1.1.0
     devDependencies:
       mermaid:
-        specifier: ^11.4.1
+        specifier: ^11.12.1
         version: 11.12.1
       vitepress:
-        specifier: ^1.5.0
+        specifier: ^1.6.4
         version: 1.6.4(@algolia/client-search@5.44.0)(postcss@8.5.6)(search-insights@2.17.3)
       vitepress-plugin-mermaid:
         specifier: ^2.0.17


### PR DESCRIPTION
- Upgrade mermaid from version 11.4.1 to 11.12.1
- Upgrade vitepress from version 1.5.0 to 1.6.4
- Update lockfile to reflect new dependency versions
- Maintain compatibility with existing documentation setup

