### PR TITLE
feat(proxy): update swagger version and autoconfigure exclusions

### DIFF
--- a/proxy/cosid-proxy-server/src/dist/config/application.yaml
+++ b/proxy/cosid-proxy-server/src/dist/config/application.yaml
@@ -16,8 +16,8 @@ spring:
     name: ${service.name:cosid-proxy}
   autoconfigure:
     exclude:
-#     - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-     - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      #     - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+      - org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 #  datasource:
 #    url: jdbc:mysql://localhost:3306/cosid_db
 #    username: root

--- a/proxy/cosid-proxy-server/src/main/java/me/ahoo/cosid/proxy/server/configuration/SwaggerConfiguration.java
+++ b/proxy/cosid-proxy-server/src/main/java/me/ahoo/cosid/proxy/server/configuration/SwaggerConfiguration.java
@@ -26,7 +26,7 @@ public class SwaggerConfiguration {
     
     @Bean
     public OpenApiCustomizer openApiCustomizer() {
-        var version = MoreObjects.firstNonNull(getClass().getPackage().getImplementationVersion(), "2.4.0");
+        var version = MoreObjects.firstNonNull(getClass().getPackage().getImplementationVersion(), "3.0.0");
         return openApi -> {
             var info = new Info()
                 .title("CosId Proxy Server")

--- a/proxy/cosid-proxy-server/src/main/resources/application.yaml
+++ b/proxy/cosid-proxy-server/src/main/resources/application.yaml
@@ -16,8 +16,8 @@ spring:
     name: ${service.name:cosid-proxy}
   autoconfigure:
     exclude:
-#     - org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration
-     - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
+      #     - org.springframework.boot.data.redis.autoconfigure.DataRedisAutoConfiguration
+      - org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
 #  datasource:
 #    url: jdbc:mysql://localhost:3306/cosid_db
 #    username: root


### PR DESCRIPTION
- Updated default swagger version from 2.4.0 to 3.0.0
- Changed autoconfigure exclusion from org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration to org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
- Updated Redis autoconfigure exclusion class path format

