### PR TITLE
refactor(proxy): replace Jackson dependencies with tools.jackson

### DIFF
--- a/proxy/cosid-proxy-api/build.gradle.kts
+++ b/proxy/cosid-proxy-api/build.gradle.kts
@@ -1,6 +1,6 @@
 dependencies{
     api(project(":cosid-core"))
+    api("tools.jackson.core:jackson-databind")
     implementation("me.ahoo.coapi:coapi-api")
-    api("com.fasterxml.jackson.core:jackson-databind")
     implementation("org.springframework:spring-web")
 }

--- a/proxy/cosid-proxy/build.gradle.kts
+++ b/proxy/cosid-proxy/build.gradle.kts
@@ -12,7 +12,6 @@
  */
 
 dependencies {
-    api("com.fasterxml.jackson.core:jackson-databind")
     api(project(":cosid-core"))
     api(project(":cosid-proxy-api"))
     implementation("org.springframework:spring-web")

--- a/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/Jsons.java
+++ b/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/Jsons.java
@@ -14,24 +14,24 @@
 package me.ahoo.cosid.proxy;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.SneakyThrows;
+import tools.jackson.core.StreamReadFeature;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 public final class Jsons {
     private Jsons() {
     }
     
-    public static final ObjectMapper OBJECT_MAPPER = mapper();
+    public static final ObjectMapper OBJECT_MAPPER = JsonMapper.builder()
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .configure(StreamReadFeature.IGNORE_UNDEFINED, true)
+        .changeDefaultPropertyInclusion(incl -> incl.withValueInclusion(JsonInclude.Include.NON_NULL))
+        .changeDefaultPropertyInclusion(incl -> incl.withContentInclusion(JsonInclude.Include.NON_NULL))
+        .build();
     
-    static ObjectMapper mapper() {
-        return new ObjectMapper()
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .configure(JsonParser.Feature.IGNORE_UNDEFINED, true)
-            .setSerializationInclusion(JsonInclude.Include.NON_NULL);
-    }
-    
+
     @SneakyThrows
     public static String serialize(Object serializeObject) {
         return OBJECT_MAPPER.writeValueAsString(serializeObject);


### PR DESCRIPTION
- Removed com.fasterxml.jackson.core:jackson-databind from cosid-proxy module
- Added tools.jackson.core:jackson-databind to cosid-proxy-api module
- Replaced ObjectMapper initialization with JsonMapper builder pattern
- Updated JSON serialization configuration to use StreamReadFeature
- Configured property inclusion settings for NON_NULL values
- Maintained existing serialization behavior with new implementation