### PR TITLE
refactor(core): replace jakarta annotation with jspecify for nullability

### DIFF
--- a/cosid-core/build.gradle.kts
+++ b/cosid-core/build.gradle.kts
@@ -12,6 +12,6 @@
  */
 
 dependencies {
-    api(libs.jakarta.annotation.api)
+    api(libs.jspecify)
     testImplementation(project(":cosid-test"))
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/Decorator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/Decorator.java
@@ -1,7 +1,7 @@
 package me.ahoo.cosid;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Decorator pattern interface for wrapping and enhancing ID generators.
@@ -36,7 +36,7 @@ public interface Decorator<D> {
      *
      * @return The actual object being decorated
      */
-    @Nonnull
+    @NonNull
     D getActual();
     
     /**

--- a/cosid-core/src/main/java/me/ahoo/cosid/IdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/IdConverter.java
@@ -17,7 +17,7 @@ import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.Statistical;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * ID converter for transforming between numeric and string representations of IDs.
@@ -52,7 +52,7 @@ public interface IdConverter extends Statistical {
      * @param id The {@code long} type ID to convert
      * @return The {@link String} representation of the ID
      */
-    @Nonnull
+    @NonNull
     String asString(long id);
     
     /**
@@ -66,7 +66,7 @@ public interface IdConverter extends Statistical {
      * @param idString The {@link String} type ID to convert
      * @return The {@code long} representation of the ID
      */
-    long asLong(@Nonnull String idString);
+    long asLong(@NonNull String idString);
     
     /**
      * Get statistical information about this converter.

--- a/cosid-core/src/main/java/me/ahoo/cosid/IdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/IdGenerator.java
@@ -18,7 +18,7 @@ import me.ahoo.cosid.stat.Statistical;
 import me.ahoo.cosid.stat.generator.IdGeneratorStat;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Id Generator.
@@ -51,7 +51,7 @@ public interface IdGenerator extends StringIdGenerator, Statistical {
      *
      * @return ID converter for transforming numeric IDs to string format
      */
-    @Nonnull
+    @NonNull
     default IdConverter idConverter() {
         return Radix62IdConverter.PAD_START;
     }
@@ -76,9 +76,8 @@ public interface IdGenerator extends StringIdGenerator, Statistical {
      *
      * @return A unique distributed ID as a string value
      */
-    @Nonnull
     @Override
-    default String generateAsString() {
+    default @NonNull String generateAsString() {
         return idConverter().asString(generate());
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/IdGeneratorDecorator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/IdGeneratorDecorator.java
@@ -3,7 +3,7 @@ package me.ahoo.cosid;
 import me.ahoo.cosid.stat.generator.IdGeneratorStat;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * IdGenerator decorator for enhancing ID generator functionality.
@@ -38,7 +38,7 @@ public interface IdGeneratorDecorator extends IdGenerator, Decorator<IdGenerator
      *
      * @return The actual ID generator being decorated
      */
-    @Nonnull
+    @NonNull
     IdGenerator getActual();
 
     /**

--- a/cosid-core/src/main/java/me/ahoo/cosid/IntegerIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/IntegerIdGenerator.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Integer ID generator that adapts a long-based ID generator to produce integer IDs.
@@ -91,9 +91,8 @@ public class IntegerIdGenerator implements StringIdGenerator {
      * @return A unique distributed ID as a string value
      * @throws IdOverflowException if the generated long ID exceeds the integer range
      */
-    @Nonnull
     @Override
-    public String generateAsString() throws IdOverflowException {
+    public @NonNull String generateAsString() throws IdOverflowException {
         long id = actual.generate();
         ensureInteger(id);
         return actual.idConverter().asString(id);

--- a/cosid-core/src/main/java/me/ahoo/cosid/StringIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/StringIdGenerator.java
@@ -15,7 +15,7 @@ package me.ahoo.cosid;
 
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * String type ID generator.
@@ -40,6 +40,6 @@ public interface StringIdGenerator {
      *
      * @return A unique distributed ID as a string value
      */
-    @Nonnull
+    @NonNull
     String generateAsString();
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/StringIdGeneratorDecorator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/StringIdGeneratorDecorator.java
@@ -13,7 +13,7 @@
 
 package me.ahoo.cosid;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * String ID generator decorator for customizing string ID generation.
@@ -72,9 +72,8 @@ public class StringIdGeneratorDecorator implements IdGeneratorDecorator {
      *
      * @return The custom ID converter
      */
-    @Nonnull
     @Override
-    public IdConverter idConverter() {
+    public @NonNull IdConverter idConverter() {
         return idConverter;
     }
     
@@ -86,7 +85,7 @@ public class StringIdGeneratorDecorator implements IdGeneratorDecorator {
      *
      * @return The actual ID generator being decorated
      */
-    @Nonnull
+    @NonNull
     @Override
     public IdGenerator getActual() {
         return actual;

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/DatePrefixIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/DatePrefixIdConverter.java
@@ -18,7 +18,7 @@ import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.DatePrefixConverterStat;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -37,22 +37,20 @@ public class DatePrefixIdConverter implements IdConverter, Decorator<IdConverter
     }
 
 
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         return LocalDateTime.now().format(formatter) + delimiter + actual.asString(id);
     }
 
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         int appendedLength = pattern.length() + delimiter.length();
         String idStr = idString.substring(appendedLength);
         return actual.asLong(idStr);
     }
 
-    @Nonnull
     @Override
-    public IdConverter getActual() {
+    public @NonNull IdConverter getActual() {
         return actual;
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/GroupedPrefixIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/GroupedPrefixIdConverter.java
@@ -19,8 +19,8 @@ import me.ahoo.cosid.segment.grouped.GroupedAccessor;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.GroupedPrefixConverterStat;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Preconditions;
+import org.jspecify.annotations.NonNull;
 
 public class GroupedPrefixIdConverter implements IdConverter, Decorator<IdConverter> {
     public static final String DEFAULT_DELIMITER = "-";
@@ -33,9 +33,8 @@ public class GroupedPrefixIdConverter implements IdConverter, Decorator<IdConver
         this.actual = actual;
     }
 
-    @Nonnull
     @Override
-    public IdConverter getActual() {
+    public @NonNull IdConverter getActual() {
         return actual;
     }
 
@@ -43,9 +42,8 @@ public class GroupedPrefixIdConverter implements IdConverter, Decorator<IdConver
         return delimiter;
     }
 
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         String idStr = actual.asString(id);
         String groupKey = GroupedAccessor.requiredGet().getKey();
         if (delimiter.isEmpty()) {
@@ -55,7 +53,7 @@ public class GroupedPrefixIdConverter implements IdConverter, Decorator<IdConver
     }
 
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         throw new UnsupportedOperationException("GroupedPrefixIdConverter does not support converting String to Long!");
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/PrefixIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/PrefixIdConverter.java
@@ -18,8 +18,8 @@ import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.PrefixConverterStat;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Preconditions;
+import org.jspecify.annotations.NonNull;
 
 
 /**
@@ -38,9 +38,8 @@ public class PrefixIdConverter implements IdConverter, Decorator<IdConverter> {
         this.actual = actual;
     }
     
-    @Nonnull
     @Override
-    public IdConverter getActual() {
+    public @NonNull IdConverter getActual() {
         return actual;
     }
     
@@ -48,9 +47,8 @@ public class PrefixIdConverter implements IdConverter, Decorator<IdConverter> {
         return prefix;
     }
     
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         String idStr = actual.asString(id);
         if (prefix.isEmpty()) {
             return idStr;
@@ -59,7 +57,7 @@ public class PrefixIdConverter implements IdConverter, Decorator<IdConverter> {
     }
     
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         String idStr = idString.substring(prefix.length());
         return actual.asLong(idStr);
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/RadixIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/RadixIdConverter.java
@@ -17,9 +17,9 @@ import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.RadixConverterStat;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import org.jspecify.annotations.NonNull;
 
 
 public abstract class RadixIdConverter implements IdConverter {
@@ -49,7 +49,7 @@ public abstract class RadixIdConverter implements IdConverter {
      * 122.
      */
     static final char LOWERCASE_Z = 'z';
-    
+
     static final char[] digits = {
         /*
          * offset: 0.
@@ -69,13 +69,13 @@ public abstract class RadixIdConverter implements IdConverter {
         LOWERCASE_A, 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm',
         'n', 'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', LOWERCASE_Z,
     };
-    
+
     public static final char PAD_CHAR = ZERO;
-    
+
     private final boolean padStart;
     private final int charSize;
     private final long maxId;
-    
+
     protected RadixIdConverter(boolean padStart, int charSize) {
         Preconditions.checkArgument(charSize > 0 && charSize <= getMaxCharSize(), "charSize cannot be greater than MAX_CHAR_SIZE[%s]!", getMaxCharSize());
         this.padStart = padStart;
@@ -86,7 +86,7 @@ public abstract class RadixIdConverter implements IdConverter {
             this.maxId = Double.valueOf(Math.pow(getRadix(), charSize)).longValue();
         }
     }
-    
+
     public static int offset(char digitChar) {
         if (digitChar >= ZERO && digitChar <= NINE) {
             return digitChar - ZERO;
@@ -99,7 +99,7 @@ public abstract class RadixIdConverter implements IdConverter {
         }
         return -1;
     }
-    
+
     public static int maxCharSize(int radix, int bits) {
         long maxId = ~(-1L << bits);
         int divideTimes = 0;
@@ -109,35 +109,34 @@ public abstract class RadixIdConverter implements IdConverter {
         }
         return divideTimes;
     }
-    
+
     boolean isPadStart() {
         return padStart;
     }
-    
+
     public int getCharSize() {
         return charSize;
     }
-    
+
     public long getMaxId() {
         return maxId;
     }
-    
+
     abstract int getRadix();
-    
+
     abstract int getMaxCharSize();
-    
-    @Nonnull
+
     @Override
-    public String asString(long id) {
-        
+    public @NonNull String asString(long id) {
+
         Preconditions.checkArgument(id > -1, "id[%s] must be greater than -1!", id);
-        
+
         final int maxCharSize = getMaxCharSize();
-        
+
         if (charSize < maxCharSize) {
             Preconditions.checkArgument(id < maxId, "id[%s] cannot be greater than maxId:[%s]!", id, maxId);
         }
-        
+
         char[] buf = new char[charSize];
         int charIdx = charSize;
         final int radix = getRadix();
@@ -146,17 +145,18 @@ public abstract class RadixIdConverter implements IdConverter {
             buf[--charIdx] = digits[mod];
             id = id / radix;
         }
-        
+
         if (padStart && charIdx > 0) {
             while (charIdx > 0) {
                 buf[--charIdx] = PAD_CHAR;
             }
         }
-        
+
         return new String(buf, charIdx, (charSize - charIdx));
     }
-    
-    public long asLong(@Nonnull String idString) {
+
+    @Override
+    public long asLong(@NonNull String idString) {
         char firstChar = idString.charAt(0);
         if (firstChar < ZERO) {
             throw new NumberFormatException(Strings.lenientFormat("For input string: [%s]!", idString));
@@ -179,7 +179,7 @@ public abstract class RadixIdConverter implements IdConverter {
         }
         return result;
     }
-    
+
     @Override
     public Stat stat() {
         return new RadixConverterStat(getClass().getSimpleName(), getRadix(), getCharSize(), isPadStart(), getMaxId());

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverter.java
@@ -19,7 +19,7 @@ import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.SnowflakeFriendlyIdConverterStat;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Snowflake FriendlyId Converter.
@@ -40,23 +40,22 @@ public class SnowflakeFriendlyIdConverter implements IdConverter {
         return snowflakeIdStateParser;
     }
 
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         return snowflakeIdStateParser.parse(id).getFriendlyId();
     }
 
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         return snowflakeIdStateParser.parse(idString).getId();
     }
 
     @Override
     public Stat stat() {
         return new SnowflakeFriendlyIdConverterStat(
-                getClass().getSimpleName(),
-                snowflakeIdStateParser.isPadStart(),
-                snowflakeIdStateParser.getMachineCharSize(),
-                snowflakeIdStateParser.getSequenceCharSize());
+            getClass().getSimpleName(),
+            snowflakeIdStateParser.isPadStart(),
+            snowflakeIdStateParser.getMachineCharSize(),
+            snowflakeIdStateParser.getSequenceCharSize());
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/SuffixIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/SuffixIdConverter.java
@@ -18,8 +18,8 @@ import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.SuffixConverterStat;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Preconditions;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Suffix IdConverter .
@@ -36,9 +36,8 @@ public class SuffixIdConverter implements IdConverter, Decorator<IdConverter> {
         this.actual = actual;
     }
 
-    @Nonnull
     @Override
-    public IdConverter getActual() {
+    public @NonNull IdConverter getActual() {
         return actual;
     }
 
@@ -46,9 +45,8 @@ public class SuffixIdConverter implements IdConverter, Decorator<IdConverter> {
         return suffix;
     }
 
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         String idStr = actual.asString(id);
         if (suffix.isEmpty()) {
             return idStr;
@@ -57,7 +55,7 @@ public class SuffixIdConverter implements IdConverter, Decorator<IdConverter> {
     }
 
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         String idStr = idString.substring(0, idString.length() - suffix.length());
         return actual.asLong(idStr);
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/converter/ToStringIdConverter.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/converter/ToStringIdConverter.java
@@ -19,8 +19,8 @@ import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.converter.ToStringConverterStat;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Strings;
+import org.jspecify.annotations.NonNull;
 
 
 /**
@@ -39,9 +39,8 @@ public class ToStringIdConverter implements IdConverter {
         this.charSize = charSize;
     }
 
-    @Nonnull
     @Override
-    public String asString(long id) {
+    public @NonNull String asString(long id) {
         String idStr = String.valueOf(id);
         if (!padStart) {
             return idStr;
@@ -50,7 +49,7 @@ public class ToStringIdConverter implements IdConverter {
     }
 
     @Override
-    public long asLong(@Nonnull String idString) {
+    public long asLong(@NonNull String idString) {
         return Long.parseLong(idString);
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/cosid/ClockSyncCosIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/cosid/ClockSyncCosIdGenerator.java
@@ -19,8 +19,8 @@ import me.ahoo.cosid.snowflake.exception.ClockBackwardsException;
 import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.generator.IdGeneratorStat;
 
-import jakarta.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 
 /**
  * ClockSync {@link CosIdGenerator}.
@@ -52,9 +52,8 @@ public class ClockSyncCosIdGenerator implements CosIdGenerator, Decorator<CosIdG
         this.clockBackwardsSynchronizer = clockBackwardsSynchronizer;
     }
     
-    @Nonnull
     @Override
-    public CosIdGenerator getActual() {
+    public @NonNull CosIdGenerator getActual() {
         return actual;
     }
     
@@ -68,15 +67,13 @@ public class ClockSyncCosIdGenerator implements CosIdGenerator, Decorator<CosIdG
         return actual.getLastTimestamp();
     }
     
-    @Nonnull
     @Override
-    public CosIdIdStateParser getStateParser() {
+    public @NonNull CosIdIdStateParser getStateParser() {
         return actual.getStateParser();
     }
     
-    @Nonnull
     @Override
-    public CosIdState generateAsState() {
+    public @NonNull CosIdState generateAsState() {
         try {
             return actual.generateAsState();
         } catch (ClockBackwardsException exception) {

--- a/cosid-core/src/main/java/me/ahoo/cosid/cosid/CosIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/cosid/CosIdGenerator.java
@@ -19,7 +19,7 @@ import me.ahoo.cosid.stat.Stat;
 import me.ahoo.cosid.stat.generator.CosIdGeneratorStat;
 import me.ahoo.cosid.stat.generator.IdGeneratorStat;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * CosId algorithm ID generator.
@@ -79,7 +79,7 @@ public interface CosIdGenerator extends IdGenerator {
      *
      * @return The state parser for this generator
      */
-    @Nonnull
+    @NonNull
     CosIdIdStateParser getStateParser();
     
     /**
@@ -92,9 +92,8 @@ public interface CosIdGenerator extends IdGenerator {
      * @return Never returns (always throws exception)
      * @throws UnsupportedOperationException always thrown because CosIdGenerator uses state parsers instead
      */
-    @Nonnull
     @Override
-    default IdConverter idConverter() {
+    default @NonNull IdConverter idConverter() {
         throw new UnsupportedOperationException("CosIdGenerator does not support IdConverter,please use CosIdIdStateParser instead!");
     }
     
@@ -122,7 +121,7 @@ public interface CosIdGenerator extends IdGenerator {
      *
      * @return The generated ID as a state object
      */
-    @Nonnull
+    @NonNull
     CosIdState generateAsState();
     
     /**
@@ -134,9 +133,8 @@ public interface CosIdGenerator extends IdGenerator {
      *
      * @return The generated ID as a string value
      */
-    @Nonnull
     @Override
-    default String generateAsString() {
+    default @NonNull String generateAsString() {
         return getStateParser().asString(generateAsState());
     }
     

--- a/cosid-core/src/main/java/me/ahoo/cosid/cosid/RadixCosIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/cosid/RadixCosIdGenerator.java
@@ -16,8 +16,8 @@ package me.ahoo.cosid.cosid;
 import me.ahoo.cosid.snowflake.exception.ClockBackwardsException;
 import me.ahoo.cosid.snowflake.exception.TimestampOverflowException;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Strings;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Radix CosIdGenerator.
@@ -75,7 +75,7 @@ public class RadixCosIdGenerator implements CosIdGenerator {
         return lastTimestamp;
     }
     
-    @Nonnull
+    @NonNull
     @Override
     public CosIdIdStateParser getStateParser() {
         return stateParser;
@@ -89,7 +89,7 @@ public class RadixCosIdGenerator implements CosIdGenerator {
         return time;
     }
     
-    @Nonnull
+    @NonNull
     public synchronized CosIdState generateAsState() {
         long currentTimestamp = System.currentTimeMillis();
         if (currentTimestamp < lastTimestamp) {

--- a/cosid-core/src/main/java/me/ahoo/cosid/jvm/UuidGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/jvm/UuidGenerator.java
@@ -15,7 +15,7 @@ package me.ahoo.cosid.jvm;
 
 import me.ahoo.cosid.IdGenerator;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.UUID;
 
@@ -33,9 +33,8 @@ public class UuidGenerator implements IdGenerator {
         throw new UnsupportedOperationException("UuidGenerator does not support the generation of long IDs!");
     }
 
-    @Nonnull
     @Override
-    public String generateAsString() {
+    public @NonNull String generateAsString() {
         return UUID.randomUUID().toString();
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/AbstractMachineIdDistributor.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/AbstractMachineIdDistributor.java
@@ -18,7 +18,7 @@ import static me.ahoo.cosid.machine.ClockBackwardsSynchronizer.getBackwardsTimeS
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Duration;
 
@@ -43,9 +43,8 @@ public abstract class AbstractMachineIdDistributor implements MachineIdDistribut
      * 2. when not found: {@link #distributeRemote}
      * 3. set {@link MachineState} to {@link MachineStateStorage}
      */
-    @Nonnull
     @Override
-    public MachineState distribute(String namespace, int machineBit, InstanceId instanceId, Duration safeGuardDuration) throws MachineIdOverflowException {
+    public @NonNull MachineState distribute(String namespace, int machineBit, InstanceId instanceId, Duration safeGuardDuration) throws MachineIdOverflowException {
         
         Preconditions.checkArgument(!Strings.isNullOrEmpty(namespace), "namespace can not be empty!");
         Preconditions.checkArgument(machineBit > 0, "machineBit:[%s] must be greater than 0!", machineBit);

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/InMemoryMachineStateStorage.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/InMemoryMachineStateStorage.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid.machine;
 
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -22,9 +22,8 @@ import java.util.concurrent.ConcurrentHashMap;
 public class InMemoryMachineStateStorage implements MachineStateStorage {
     private final ConcurrentHashMap<NamespacedInstanceId, MachineState> states = new ConcurrentHashMap<>();
     
-    @Nonnull
     @Override
-    public MachineState get(String namespace, InstanceId instanceId) {
+    public @NonNull MachineState get(String namespace, InstanceId instanceId) {
         return states.getOrDefault(new NamespacedInstanceId(namespace, instanceId), MachineState.NOT_FOUND);
     }
     

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/LocalMachineStateStorage.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/LocalMachineStateStorage.java
@@ -21,7 +21,7 @@ import com.google.common.base.Strings;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Files;
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -46,9 +46,8 @@ public class LocalMachineStateStorage implements MachineStateStorage {
         this(DEFAULT_STATE_LOCATION_PATH);
     }
 
-    @Nonnull
     @Override
-    public MachineState get(String namespace, InstanceId instanceId) {
+    public @NonNull MachineState get(String namespace, InstanceId instanceId) {
         Preconditions.checkArgument(!Strings.isNullOrEmpty(namespace), "namespace can not be empty!");
         Preconditions.checkNotNull(instanceId, "instanceId can not be null!");
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineIdDistributor.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineIdDistributor.java
@@ -15,51 +15,50 @@ package me.ahoo.cosid.machine;
 
 import com.google.common.base.Strings;
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
 
 import java.time.Duration;
 
 /**
  * Machine ID distributor for coordinating unique machine identifiers in distributed systems.
- * 
+ *
  * <p>In distributed ID generation, each machine or instance must have a unique identifier
  * to ensure global uniqueness of generated IDs. This interface provides the contract for
  * distributing and managing these machine IDs across a cluster.
- * 
+ *
  * <p>The distributor is responsible for:
  * <ul>
  *   <li>Allocating unique machine IDs within a namespace</li>
  *   <li>Reverting (releasing) machine IDs when instances shut down</li>
  *   <li>Guarding machine IDs with heartbeats to detect failures</li>
  * </ul>
- * 
+ *
  * <p>Common implementations include:
  * <ul>
  *   <li>Redis-based distribution</li>
  *   <li>ZooKeeper-based distribution</li>
  *   <li>JDBC-based distribution</li>
  * </ul>
- * 
+ *
  * <p><img src="../../doc-files/Machine-Id-Safe-Guard.png" alt="Machine-Id-Safe-Guard"></p>
- * 
+ *
  * <p>Implementations of this interface are expected to be thread-safe and can be
  * used concurrently across multiple threads.
  *
  * @author ahoo wang
  */
 @ThreadSafe
-public interface MachineIdDistributor {
+public interface MachineIdDistributor extends MachineIdDistribute {
     /**
      * A duration representing forever for safe guard purposes.
-     * 
+     *
      * <p>This constant is used to indicate that machine ID guarding should
      * persist indefinitely, without expiration.
      */
     Duration FOREVER_SAFE_GUARD_DURATION = Duration.ofMillis(Long.MAX_VALUE);
-    
+
     /**
      * Calculate the maximum machine ID for the specified bit size.
-     * 
+     *
      * <p>This method calculates the largest machine ID that can be represented
      * with the given number of bits, which determines how many unique machines
      * can participate in ID generation.
@@ -70,10 +69,10 @@ public interface MachineIdDistributor {
     static int maxMachineId(int machineBit) {
         return ~(-1 << machineBit);
     }
-    
+
     /**
      * Calculate the total number of machine IDs for the specified bit size.
-     * 
+     *
      * <p>This method calculates the total number of unique machine IDs that
      * can be allocated with the given bit size, including zero.
      *
@@ -83,10 +82,10 @@ public interface MachineIdDistributor {
     static int totalMachineIds(int machineBit) {
         return maxMachineId(machineBit) + 1;
     }
-    
+
     /**
      * Generate a namespaced machine ID string.
-     * 
+     *
      * <p>This method creates a formatted string that combines a namespace
      * with a machine ID, padding the machine ID with leading zeros to
      * ensure consistent formatting.
@@ -98,82 +97,62 @@ public interface MachineIdDistributor {
     static String namespacedMachineId(String namespace, int machineId) {
         return namespace + "." + Strings.padStart(String.valueOf(machineId), 8, '0');
     }
-    
+
     /**
      * Calculate the safe guard timestamp.
-     * 
+     *
      * <p>This method calculates the timestamp before which a machine ID
      * should be considered stale and potentially reallocated if not
      * guarded by a heartbeat.
      *
      * @param safeGuardDuration The duration for safe guarding
-     * @param stable Whether the system is in a stable state
+     * @param stable            Whether the system is in a stable state
      * @return The safe guard timestamp
      */
     static long getSafeGuardAt(Duration safeGuardDuration, boolean stable) {
         if (stable) {
             return 0L;
         }
-        
+
         if (FOREVER_SAFE_GUARD_DURATION.equals(safeGuardDuration)) {
             return 0L;
         }
-        
+
         long safeGuardAt = System.currentTimeMillis() - safeGuardDuration.toMillis();
         if (safeGuardAt < 0) {
             return 0L;
         }
         return safeGuardAt;
     }
-    
-    /**
-     * Distribute (allocate) a machine ID within the specified namespace.
-     * 
-     * <p>This method allocates a unique machine ID for the given instance
-     * within the specified namespace. The allocated ID is guaranteed to
-     * be unique within that namespace for the duration of its lease.
-     * 
-     * <p>The method returns a {@link MachineState} object containing the
-     * allocated machine ID and associated metadata.
-     *
-     * @param namespace The namespace for machine ID allocation
-     * @param machineBit The number of bits to use for machine IDs
-     * @param instanceId The instance identifier requesting the machine ID
-     * @param safeGuardDuration The duration for safe guarding the allocation
-     * @return The machine state containing the allocated machine ID
-     * @throws MachineIdOverflowException if no more machine IDs are available
-     */
-    @Nonnull
-    MachineState distribute(String namespace, int machineBit, InstanceId instanceId, Duration safeGuardDuration) throws MachineIdOverflowException;
-    
+
     /**
      * Revert (release) a previously allocated machine ID.
-     * 
+     *
      * <p>This method releases a machine ID back to the distributor, making
      * it available for reallocation. This should be called when an instance
      * shuts down gracefully to enable efficient reuse of machine IDs.
      *
-     * @param namespace The namespace of the machine ID
+     * @param namespace  The namespace of the machine ID
      * @param instanceId The instance identifier whose machine ID should be released
      * @throws NotFoundMachineStateException if the machine ID was not found
      */
     void revert(String namespace, InstanceId instanceId) throws NotFoundMachineStateException;
-    
+
     /**
      * Guard a machine ID with a heartbeat mechanism.
-     * 
+     *
      * <p>This method updates the heartbeat timestamp for a machine ID to
      * prevent it from being considered stale and reallocated. It should
      * be called periodically by instances to maintain their machine ID lease.
-     * 
+     *
      * <p><img src="../../doc-files/Machine-Id-Safe-Guard.png" alt="Machine-Id-Safe-Guard"></p>
      *
-     * @param namespace The namespace of the machine ID
-     * @param instanceId The instance identifier whose machine ID should be guarded
+     * @param namespace         The namespace of the machine ID
+     * @param instanceId        The instance identifier whose machine ID should be guarded
      * @param safeGuardDuration The duration for safe guarding the allocation
      * @throws NotFoundMachineStateException if the machine ID was not found
-     * @throws MachineIdLostException if the machine ID has been lost or reallocated
+     * @throws MachineIdLostException        if the machine ID has been lost or reallocated
      */
     void guard(String namespace, InstanceId instanceId, Duration safeGuardDuration) throws NotFoundMachineStateException, MachineIdLostException;
-    
+
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineIdLostException.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineIdLostException.java
@@ -16,7 +16,7 @@ package me.ahoo.cosid.machine;
 import me.ahoo.cosid.CosIdException;
 
 import com.google.common.base.Strings;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 /**
  * MachineId Lost Exception .

--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineStateStorage.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/MachineStateStorage.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid.machine;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Machine State Storage.
@@ -26,7 +26,7 @@ public interface MachineStateStorage {
     MachineStateStorage LOCAL = new LocalMachineStateStorage();
     MachineStateStorage IN_MEMORY = new InMemoryMachineStateStorage();
 
-    @Nonnull
+    @NonNull
     MachineState get(String namespace, InstanceId instanceId);
 
     void set(String namespace, int machineId, InstanceId instanceId);

--- a/cosid-core/src/main/java/me/ahoo/cosid/provider/LazyIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/provider/LazyIdGenerator.java
@@ -21,8 +21,8 @@ import me.ahoo.cosid.segment.SegmentId;
 import me.ahoo.cosid.snowflake.SnowflakeFriendlyId;
 import me.ahoo.cosid.snowflake.SnowflakeId;
 
-import jakarta.annotation.Nonnull;
 import com.google.common.base.Strings;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Optional;
 
@@ -100,15 +100,13 @@ public final class LazyIdGenerator implements IdGeneratorDecorator {
         throw new CosIdException(Strings.lenientFormat("IdGenerator:[%s] is not instanceof SegmentId!", generatorName));
     }
     
-    @Nonnull
     @Override
-    public IdGenerator getActual() {
+    public @NonNull IdGenerator getActual() {
         return tryGet(true);
     }
     
-    @Nonnull
     @Override
-    public IdConverter idConverter() {
+    public @NonNull IdConverter idConverter() {
         return getActual().idConverter();
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentDistributor.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentDistributor.java
@@ -21,7 +21,7 @@ import me.ahoo.cosid.util.Clock;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -80,7 +80,7 @@ public interface IdSegmentDistributor extends Grouped {
      *
      * @return The namespace
      */
-    @Nonnull
+    @NonNull
     String getNamespace();
 
     /**
@@ -90,7 +90,7 @@ public interface IdSegmentDistributor extends Grouped {
      *
      * @return The name
      */
-    @Nonnull
+    @NonNull
     String getName();
 
     /**
@@ -177,7 +177,7 @@ public interface IdSegmentDistributor extends Grouped {
      *
      * @return The allocated ID segment
      */
-    @Nonnull
+    @NonNull
     default IdSegment nextIdSegment() {
         return nextIdSegment(TIME_TO_LIVE_FOREVER);
     }
@@ -188,7 +188,7 @@ public interface IdSegmentDistributor extends Grouped {
      * @param ttl The time-to-live for the segment
      * @return The allocated ID segment
      */
-    @Nonnull
+    @NonNull
     default IdSegment nextIdSegment(long ttl) {
         Preconditions.checkArgument(ttl > 0, "ttl:[%s] must be greater than 0.", ttl);
 
@@ -206,7 +206,7 @@ public interface IdSegmentDistributor extends Grouped {
      * @param ttl      The time-to-live for the segment
      * @return The allocated merged ID segment
      */
-    @Nonnull
+    @NonNull
     default IdSegment nextIdSegment(int segments, long ttl) {
         Preconditions.checkArgument(segments > 0, "segments:[%s] must be greater than 0.", segments);
         Preconditions.checkArgument(ttl > 0, "ttl:[%s] must be greater than 0.", ttl);
@@ -223,7 +223,7 @@ public interface IdSegmentDistributor extends Grouped {
      * @param previousChain The previous segment chain
      * @return The allocated ID segment chain
      */
-    @Nonnull
+    @NonNull
     default IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain) {
         return nextIdSegmentChain(previousChain, DEFAULT_SEGMENTS, TIME_TO_LIVE_FOREVER);
     }
@@ -239,7 +239,7 @@ public interface IdSegmentDistributor extends Grouped {
      * @param ttl           The time-to-live for the segment
      * @return The allocated ID segment chain
      */
-    @Nonnull
+    @NonNull
     default IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain, int segments, long ttl) {
         if (DEFAULT_SEGMENTS == segments) {
             IdSegment nextIdSegment = nextIdSegment(ttl);
@@ -294,9 +294,8 @@ public interface IdSegmentDistributor extends Grouped {
          *
          * @return The namespace
          */
-        @Nonnull
         @Override
-        public String getNamespace() {
+        public @NonNull String getNamespace() {
             return "__";
         }
 
@@ -305,9 +304,8 @@ public interface IdSegmentDistributor extends Grouped {
          *
          * @return The name
          */
-        @Nonnull
         @Override
-        public String getName() {
+        public @NonNull String getName() {
             return name;
         }
 
@@ -372,9 +370,8 @@ public interface IdSegmentDistributor extends Grouped {
          *
          * @return The namespace
          */
-        @Nonnull
         @Override
-        public String getNamespace() {
+        public @NonNull String getNamespace() {
             return "__";
         }
 
@@ -383,9 +380,8 @@ public interface IdSegmentDistributor extends Grouped {
          *
          * @return The name
          */
-        @Nonnull
         @Override
-        public String getName() {
+        public @NonNull String getName() {
             return name;
         }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentDistributorFactory.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/IdSegmentDistributorFactory.java
@@ -13,7 +13,8 @@
 
 package me.ahoo.cosid.segment;
 
-import jakarta.annotation.Nonnull;
+
+import org.jspecify.annotations.NonNull;
 
 /**
  * {@link IdSegmentDistributor} Factory.
@@ -22,6 +23,6 @@ import jakarta.annotation.Nonnull;
  */
 @FunctionalInterface
 public interface IdSegmentDistributorFactory {
-    @Nonnull
+    @NonNull
     IdSegmentDistributor create(IdSegmentDistributorDefinition definition);
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/DefaultGroupedIdSegmentDistributor.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/DefaultGroupedIdSegmentDistributor.java
@@ -19,7 +19,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 public class DefaultGroupedIdSegmentDistributor implements GroupedIdSegmentDistributor {
     private final GroupBySupplier groupBySupplier;
@@ -58,15 +58,13 @@ public class DefaultGroupedIdSegmentDistributor implements GroupedIdSegmentDistr
         return groupBySupplier;
     }
     
-    @Nonnull
     @Override
-    public String getNamespace() {
+    public @NonNull String getNamespace() {
         return this.idSegmentDistributorDefinition.getNamespace();
     }
     
-    @Nonnull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return this.idSegmentDistributorDefinition.getName();
     }
     
@@ -90,33 +88,28 @@ public class DefaultGroupedIdSegmentDistributor implements GroupedIdSegmentDistr
         return this.ensureGroupedBinding().nextMaxId(step);
     }
     
-    @Nonnull
     @Override
-    public IdSegment nextIdSegment() {
+    public @NonNull IdSegment nextIdSegment() {
         return this.ensureGroupedBinding().nextIdSegment();
     }
     
-    @Nonnull
     @Override
-    public IdSegment nextIdSegment(long ttl) {
+    public @NonNull IdSegment nextIdSegment(long ttl) {
         return this.ensureGroupedBinding().nextIdSegment(ttl);
     }
     
-    @Nonnull
     @Override
-    public IdSegment nextIdSegment(int segments, long ttl) {
+    public @NonNull IdSegment nextIdSegment(int segments, long ttl) {
         return this.ensureGroupedBinding().nextIdSegment(segments, ttl);
     }
     
-    @Nonnull
     @Override
-    public IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain, int segments, long ttl) {
+    public @NonNull IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain, int segments, long ttl) {
         return this.ensureGroupedBinding().nextIdSegmentChain(previousChain, segments, ttl);
     }
     
-    @Nonnull
     @Override
-    public IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain) {
+    public @NonNull IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain) {
         return this.ensureGroupedBinding().nextIdSegmentChain(previousChain);
     }
     
@@ -135,15 +128,13 @@ public class DefaultGroupedIdSegmentDistributor implements GroupedIdSegmentDistr
             return group;
         }
         
-        @Nonnull
         @Override
-        public String getNamespace() {
+        public @NonNull String getNamespace() {
             return idSegmentDistributor.getNamespace();
         }
         
-        @Nonnull
         @Override
-        public String getName() {
+        public @NonNull String getName() {
             return idSegmentDistributor.getName();
         }
         
@@ -162,23 +153,20 @@ public class DefaultGroupedIdSegmentDistributor implements GroupedIdSegmentDistr
             return Math.min(groupedTtl, ttl);
         }
         
-        @Nonnull
         @Override
-        public IdSegment nextIdSegment(long ttl) {
+        public @NonNull IdSegment nextIdSegment(long ttl) {
             long minTtl = getMinTtl(ttl);
             return GroupedIdSegmentDistributor.super.nextIdSegment(minTtl);
         }
         
-        @Nonnull
         @Override
-        public IdSegment nextIdSegment(int segments, long ttl) {
+        public @NonNull IdSegment nextIdSegment(int segments, long ttl) {
             long minTtl = getMinTtl(ttl);
             return GroupedIdSegmentDistributor.super.nextIdSegment(segments, minTtl);
         }
         
-        @Nonnull
         @Override
-        public IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain, int segments, long ttl) {
+        public @NonNull IdSegmentChain nextIdSegmentChain(IdSegmentChain previousChain, int segments, long ttl) {
             long minTtl = getMinTtl(ttl);
             return GroupedIdSegmentDistributor.super.nextIdSegmentChain(previousChain, segments, minTtl);
         }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/GroupedAccessor.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/GroupedAccessor.java
@@ -14,34 +14,34 @@
 package me.ahoo.cosid.segment.grouped;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Objects;
 
 @ThreadSafe
 public final class GroupedAccessor {
     private static final ThreadLocal<GroupedKey> CURRENT = new ThreadLocal<>();
-    
+
     public static void set(GroupedKey groupedKey) {
         CURRENT.set(groupedKey);
     }
-    
+
     public static void setIfNotNever(GroupedKey groupedKey) {
         if (GroupedKey.NEVER.equals(groupedKey)) {
             return;
         }
         set(groupedKey);
     }
-    
-    @Nullable
+
     public static GroupedKey get() {
         return CURRENT.get();
     }
-    
+
+    @NonNull
     public static GroupedKey requiredGet() {
         return Objects.requireNonNull(get(), "The current thread has not set the GroupedKey.");
     }
-    
+
     public static void clear() {
         CURRENT.remove();
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/GroupedIdSegmentDistributorFactory.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/segment/grouped/GroupedIdSegmentDistributorFactory.java
@@ -17,7 +17,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 public class GroupedIdSegmentDistributorFactory implements IdSegmentDistributorFactory {
     private final GroupBySupplier groupBySupplier;
@@ -28,9 +28,8 @@ public class GroupedIdSegmentDistributorFactory implements IdSegmentDistributorF
         this.actual = actual;
     }
     
-    @Nonnull
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         return new DefaultGroupedIdSegmentDistributor(groupBySupplier, definition, actual);
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/CachedSharding.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/CachedSharding.java
@@ -18,7 +18,7 @@ import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Range;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
 
@@ -40,28 +40,25 @@ public class CachedSharding<T extends Comparable<?>> implements Sharding<T> {
             .build(new LoadShardingCache());
     }
 
-    @Nonnull
     @Override
-    public String sharding(T shardingValue) {
+    public @NonNull String sharding(T shardingValue) {
         return actual.sharding(shardingValue);
     }
 
-    @Nonnull
     @Override
-    public Collection<String> sharding(Range<T> shardingValue) {
+    public @NonNull Collection<String> sharding(Range<T> shardingValue) {
         return shardingCache.getUnchecked(shardingValue);
     }
 
-    @Nonnull
     @Override
-    public Collection<String> getEffectiveNodes() {
+    public @NonNull Collection<String> getEffectiveNodes() {
         return actual.getEffectiveNodes();
     }
 
     private class LoadShardingCache extends CacheLoader<Range<T>, Collection<String>> {
 
         @Override
-        public Collection<String> load(@Nonnull Range<T> key) {
+        public Collection<String> load(@NonNull Range<T> key) {
             return actual.sharding(key);
         }
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/IntervalTimeline.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/IntervalTimeline.java
@@ -17,7 +17,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -85,23 +85,20 @@ public class IntervalTimeline implements Sharding<LocalDateTime> {
         return startInterval;
     }
 
-    @Nonnull
     @Override
-    public Collection<String> getEffectiveNodes() {
+    public @NonNull Collection<String> getEffectiveNodes() {
         return effectiveNodes;
     }
 
-    @Nonnull
     @Override
-    public String sharding(LocalDateTime shardingValue) {
+    public @NonNull String sharding(LocalDateTime shardingValue) {
         Preconditions.checkArgument(contains(shardingValue), "Sharding value:[%s]: out of bounds:[%s].", shardingValue, effectiveInterval);
         int offset = step.offsetUnit(startInterval.getLower(), shardingValue);
         return effectiveIntervals[offset].getNode();
     }
 
-    @Nonnull
     @Override
-    public Collection<String> sharding(Range<LocalDateTime> shardingValue) {
+    public @NonNull Collection<String> sharding(Range<LocalDateTime> shardingValue) {
 
         if (!effectiveInterval.isConnected(shardingValue)) {
             return ExactCollection.empty();

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
@@ -16,7 +16,7 @@ package me.ahoo.cosid.sharding;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.BoundType;
 import com.google.common.collect.Range;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
 
@@ -54,16 +54,14 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
         return divisor;
     }
 
-    @Nonnull
     @Override
-    public String sharding(T shardingValue) {
+    public @NonNull String sharding(T shardingValue) {
         int nodeIdx = (int) (shardingValue.longValue() % divisor);
         return effectiveNodes.get(nodeIdx);
     }
 
-    @Nonnull
     @Override
-    public Collection<String> sharding(Range<T> shardingValue) {
+    public @NonNull Collection<String> sharding(Range<T> shardingValue) {
 
         if (Range.all().equals(shardingValue)) {
             return effectiveNodes;
@@ -105,9 +103,8 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
         return nodes;
     }
 
-    @Nonnull
     @Override
-    public Collection<String> getEffectiveNodes() {
+    public @NonNull Collection<String> getEffectiveNodes() {
         return effectiveNodes;
     }
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/PreciseSharding.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/PreciseSharding.java
@@ -13,9 +13,9 @@
 
 package me.ahoo.cosid.sharding;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 public interface PreciseSharding<T extends Comparable<?>> {
-    @Nonnull
+    @NonNull
     String sharding(T shardingValue);
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/RangeSharding.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/RangeSharding.java
@@ -14,11 +14,11 @@
 package me.ahoo.cosid.sharding;
 
 import com.google.common.collect.Range;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
 
 public interface RangeSharding<T extends Comparable<?>> {
-    @Nonnull
+    @NonNull
     Collection<String> sharding(Range<T> shardingValue);
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/Sharding.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/Sharding.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid.sharding;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.Collection;
 
@@ -27,6 +27,6 @@ import java.util.Collection;
  */
 @ThreadSafe
 public interface Sharding<T extends Comparable<?>> extends PreciseSharding<T>, RangeSharding<T> {
-    @Nonnull
+    @NonNull
     Collection<String> getEffectiveNodes();
 }

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/ClockSyncSnowflakeId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/ClockSyncSnowflakeId.java
@@ -18,8 +18,8 @@ import me.ahoo.cosid.machine.ClockBackwardsSynchronizer;
 import me.ahoo.cosid.snowflake.exception.ClockBackwardsException;
 import me.ahoo.cosid.stat.generator.IdGeneratorStat;
 
-import jakarta.annotation.Nonnull;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Clock Sync SnowflakeId.
@@ -41,9 +41,8 @@ public class ClockSyncSnowflakeId implements IdGeneratorDecorator, SnowflakeId {
         this.clockBackwardsSynchronizer = clockBackwardsSynchronizer;
     }
 
-    @Nonnull
     @Override
-    public SnowflakeId getActual() {
+    public @NonNull SnowflakeId getActual() {
         return actual;
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/DefaultSnowflakeFriendlyId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/DefaultSnowflakeFriendlyId.java
@@ -16,7 +16,7 @@ package me.ahoo.cosid.snowflake;
 import me.ahoo.cosid.IdConverter;
 import me.ahoo.cosid.converter.SnowflakeFriendlyIdConverter;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.ZoneId;
 
@@ -46,9 +46,8 @@ public class DefaultSnowflakeFriendlyId extends StringSnowflakeId implements Sno
         this.snowflakeIdStateParser = snowflakeIdStateParser;
     }
 
-    @Nonnull
     @Override
-    public SnowflakeIdStateParser getParser() {
+    public @NonNull SnowflakeIdStateParser getParser() {
         return snowflakeIdStateParser;
     }
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeFriendlyId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeFriendlyId.java
@@ -13,7 +13,7 @@
 
 package me.ahoo.cosid.snowflake;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Snowflake FriendlyId.
@@ -22,21 +22,21 @@ import jakarta.annotation.Nonnull;
  */
 public interface SnowflakeFriendlyId extends SnowflakeId {
     
-    @Nonnull
+    @NonNull
     SnowflakeIdStateParser getParser();
     
-    @Nonnull
+    @NonNull
     default SnowflakeIdState friendlyId(long id) {
         return getParser().parse(id);
     }
     
-    @Nonnull
+    @NonNull
     default SnowflakeIdState friendlyId() {
         long id = generate();
         return friendlyId(id);
     }
     
-    @Nonnull
+    @NonNull
     default SnowflakeIdState ofFriendlyId(String friendlyId) {
         return getParser().parse(friendlyId);
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdState.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdState.java
@@ -13,8 +13,8 @@
 
 package me.ahoo.cosid.snowflake;
 
-import jakarta.annotation.Nonnull;
 import com.google.errorprone.annotations.Immutable;
+import org.jspecify.annotations.NonNull;
 
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -63,12 +63,12 @@ public class SnowflakeIdState implements Comparable<SnowflakeIdState> {
         return sequence;
     }
     
-    @Nonnull
+    @NonNull
     public LocalDateTime getTimestamp() {
         return timestamp;
     }
     
-    @Nonnull
+    @NonNull
     public String getFriendlyId() {
         return friendlyId;
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/stat/Stat.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/stat/Stat.java
@@ -13,7 +13,7 @@
 
 package me.ahoo.cosid.stat;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public interface Stat {
 

--- a/cosid-core/src/main/java/me/ahoo/cosid/stat/generator/IdGeneratorStat.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/stat/generator/IdGeneratorStat.java
@@ -15,7 +15,7 @@ package me.ahoo.cosid.stat.generator;
 
 import me.ahoo.cosid.stat.Stat;
 
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 public interface IdGeneratorStat extends Stat {
     @Nullable

--- a/cosid-core/src/main/java/me/ahoo/cosid/uncertainty/UncertaintyIdGenerator.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/uncertainty/UncertaintyIdGenerator.java
@@ -19,7 +19,7 @@ import me.ahoo.cosid.snowflake.SnowflakeId;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -68,9 +68,8 @@ public class UncertaintyIdGenerator implements IdGeneratorDecorator {
         return ThreadLocalRandom.current().nextLong(0, uncertaintyBound);
     }
     
-    @Nonnull
     @Override
-    public IdGenerator getActual() {
+    public @NonNull IdGenerator getActual() {
         return actual;
     }
     

--- a/cosid-core/src/main/java/me/ahoo/cosid/util/LocalDateTimeConvert.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/util/LocalDateTimeConvert.java
@@ -14,7 +14,7 @@
 package me.ahoo.cosid.util;
 
 import com.google.errorprone.annotations.ThreadSafe;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.time.Instant;
 import java.time.LocalDate;
@@ -35,22 +35,22 @@ public final class LocalDateTimeConvert {
     private LocalDateTimeConvert() {
     }
     
-    @Nonnull
+    @NonNull
     public static LocalDateTime fromDate(Date date, ZoneId zoneId) {
         return fromTimestamp(date.getTime(), zoneId);
     }
     
-    @Nonnull
+    @NonNull
     public static LocalDateTime fromTimestamp(long timestamp, ZoneId zoneId) {
         return fromInstant(Instant.ofEpochMilli(timestamp), zoneId);
     }
     
-    @Nonnull
+    @NonNull
     public static LocalDateTime fromTimestampSecond(long timestamp, ZoneId zoneId) {
         return fromInstant(Instant.ofEpochSecond(timestamp), zoneId);
     }
     
-    @Nonnull
+    @NonNull
     public static LocalDateTime fromInstant(Instant instant, ZoneId zoneId) {
         return LocalDateTime.ofInstant(instant, zoneId);
     }
@@ -62,7 +62,7 @@ public final class LocalDateTimeConvert {
      * @param dateTimeFormatter date time formatter
      * @return LocalDateTime from string
      */
-    @Nonnull
+    @NonNull
     public static LocalDateTime fromString(String dateTime, DateTimeFormatter dateTimeFormatter) {
         TemporalAccessor temporalAccessor = dateTimeFormatter.parseBest(dateTime, LocalDateTime::from, LocalDate::from);
         if (temporalAccessor instanceof LocalDateTime) {

--- a/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributor.java
+++ b/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributor.java
@@ -21,7 +21,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import javax.sql.DataSource;
 import java.sql.Connection;
@@ -69,15 +69,13 @@ public class JdbcIdSegmentDistributor implements IdSegmentDistributor {
         this.dataSource = dataSource;
     }
 
-    @Nonnull
     @Override
-    public String getNamespace() {
+    public @NonNull String getNamespace() {
         return namespace;
     }
 
-    @Nonnull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return name;
     }
 

--- a/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributorFactory.java
+++ b/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcIdSegmentDistributorFactory.java
@@ -17,7 +17,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import javax.sql.DataSource;
 
@@ -41,9 +41,8 @@ public class JdbcIdSegmentDistributorFactory implements IdSegmentDistributorFact
         this.fetchMaxIdSql = fetchMaxIdSql;
     }
 
-    @Nonnull
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         if (enableAutoInitIdSegment) {
             jdbcIdSegmentInitializer.tryInitIdSegment(definition.getNamespacedName(), definition.getOffset());
         }

--- a/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/MongoIdSegmentDistributor.java
+++ b/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/MongoIdSegmentDistributor.java
@@ -16,7 +16,7 @@ package me.ahoo.cosid.mongo;
 import me.ahoo.cosid.segment.IdSegmentDistributor;
 
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Mongo IdSegment Distributor.
@@ -37,15 +37,13 @@ public class MongoIdSegmentDistributor implements IdSegmentDistributor {
         this.idSegmentCollection = idSegmentCollection;
     }
     
-    @Nonnull
     @Override
-    public String getNamespace() {
+    public @NonNull String getNamespace() {
         return namespace;
     }
     
-    @Nonnull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return name;
     }
     

--- a/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/MongoIdSegmentDistributorFactory.java
+++ b/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/MongoIdSegmentDistributorFactory.java
@@ -20,6 +20,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
 import com.mongodb.client.MongoDatabase;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Mongo IdSegment Distributor Factory.
@@ -34,7 +35,7 @@ public class MongoIdSegmentDistributorFactory implements IdSegmentDistributorFac
     }
     
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         MongoIdSegmentCollection cosIdSegmentCollection = new MongoIdSegmentCollection(mongoDatabase.getCollection(COLLECTION_NAME));
 
         return new MongoIdSegmentDistributor(definition.getNamespace(),

--- a/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/reactive/MongoReactiveIdSegmentDistributorFactory.java
+++ b/cosid-mongo/src/main/java/me/ahoo/cosid/mongo/reactive/MongoReactiveIdSegmentDistributorFactory.java
@@ -22,6 +22,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
 import com.mongodb.reactivestreams.client.MongoDatabase;
+import org.jspecify.annotations.NonNull;
 
 public class MongoReactiveIdSegmentDistributorFactory implements IdSegmentDistributorFactory {
     private final MongoDatabase mongoDatabase;
@@ -31,7 +32,7 @@ public class MongoReactiveIdSegmentDistributorFactory implements IdSegmentDistri
     }
     
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         IdSegmentCollection idSegmentCollection = new MongoReactiveIdSegmentCollection(mongoDatabase.getCollection(COLLECTION_NAME));
         
         return new MongoIdSegmentDistributor(definition.getNamespace(),

--- a/cosid-spring-data-jdbc/src/main/java/me/ahoo/cosid/spring/data/jdbc/CosIdBeforeConvertCallback.java
+++ b/cosid-spring-data-jdbc/src/main/java/me/ahoo/cosid/spring/data/jdbc/CosIdBeforeConvertCallback.java
@@ -15,8 +15,8 @@ package me.ahoo.cosid.spring.data.jdbc;
 
 import me.ahoo.cosid.accessor.registry.CosIdAccessorRegistry;
 
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.relational.core.mapping.event.BeforeConvertCallback;
-import jakarta.annotation.Nonnull;
 
 
 public class CosIdBeforeConvertCallback implements BeforeConvertCallback<Object> {
@@ -26,9 +26,9 @@ public class CosIdBeforeConvertCallback implements BeforeConvertCallback<Object>
         this.accessorRegistry = accessorRegistry;
     }
     
-    @Nonnull
+    @NonNull
     @Override
-    public Object onBeforeConvert(@Nonnull Object aggregate) {
+    public Object onBeforeConvert(@NonNull Object aggregate) {
         accessorRegistry.ensureId(aggregate);
         return aggregate;
     }

--- a/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributor.java
+++ b/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributor.java
@@ -21,8 +21,8 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import jakarta.annotation.Nonnull;
 
 /**
  * Spring Redis IdSegmentDistributor.
@@ -82,15 +82,13 @@ public class SpringRedisIdSegmentDistributor implements IdSegmentDistributor {
         return adderKey;
     }
     
-    @Nonnull
     @Override
-    public String getNamespace() {
+    public @NonNull String getNamespace() {
         return namespace;
     }
     
-    @Nonnull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return name;
     }
     

--- a/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributorFactory.java
+++ b/cosid-spring-redis/src/main/java/me/ahoo/cosid/spring/redis/SpringRedisIdSegmentDistributorFactory.java
@@ -17,8 +17,8 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.redis.core.StringRedisTemplate;
-import jakarta.annotation.Nonnull;
 
 
 /**
@@ -34,9 +34,8 @@ public class SpringRedisIdSegmentDistributorFactory implements IdSegmentDistribu
         this.redisTemplate = redisTemplate;
     }
     
-    @Nonnull
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         SpringRedisIdSegmentDistributor springRedisIdSegmentDistributor = new SpringRedisIdSegmentDistributor(
             definition.getNamespace(),
             definition.getName(),

--- a/cosid-zookeeper/src/main/java/me/ahoo/cosid/zookeeper/ZookeeperIdSegmentDistributor.java
+++ b/cosid-zookeeper/src/main/java/me/ahoo/cosid/zookeeper/ZookeeperIdSegmentDistributor.java
@@ -26,7 +26,7 @@ import org.apache.curator.framework.CuratorFramework;
 import org.apache.curator.framework.recipes.atomic.AtomicValue;
 import org.apache.curator.framework.recipes.atomic.DistributedAtomicLong;
 import org.apache.curator.framework.recipes.atomic.PromotedToLock;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 import java.util.concurrent.TimeUnit;
 
@@ -71,15 +71,13 @@ public class ZookeeperIdSegmentDistributor implements IdSegmentDistributor {
         this.distributedAtomicLong = new DistributedAtomicLong(curatorFramework, counterPath, retryPolicy, promotedToLock);
     }
     
-    @Nonnull
     @Override
-    public String getNamespace() {
+    public @NonNull String getNamespace() {
         return namespace;
     }
     
-    @Nonnull
     @Override
-    public String getName() {
+    public @NonNull String getName() {
         return name;
     }
     

--- a/cosid-zookeeper/src/main/java/me/ahoo/cosid/zookeeper/ZookeeperIdSegmentDistributorFactory.java
+++ b/cosid-zookeeper/src/main/java/me/ahoo/cosid/zookeeper/ZookeeperIdSegmentDistributorFactory.java
@@ -19,7 +19,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
 import org.apache.curator.RetryPolicy;
 import org.apache.curator.framework.CuratorFramework;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * Zookeeper IdSegmentDistributor Factory.
@@ -35,9 +35,8 @@ public class ZookeeperIdSegmentDistributorFactory implements IdSegmentDistributo
         this.retryPolicy = retryPolicy;
     }
     
-    @Nonnull
     @Override
-    public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+    public @NonNull IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
         ZookeeperIdSegmentDistributor zookeeperIdSegmentDistributor = new ZookeeperIdSegmentDistributor(
             definition.getNamespace(),
             definition.getName(),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # libraries
 spring-boot = "3.5.8"
 spring-cloud = "2025.0.0"
-jakarta-annotation-api = "3.0.0"
+jspecify = "1.0.0"
 coapi = "1.12.8"
 testcontainers = "1.21.3"
 guava = "33.5.0-jre"
@@ -25,7 +25,7 @@ spotbugs = "6.4.7"
 [libraries]
 spring-boot-dependencies = { module = "org.springframework.boot:spring-boot-dependencies", version.ref = "spring-boot" }
 spring-cloud-dependencies = { module = "org.springframework.cloud:spring-cloud-dependencies", version.ref = "spring-cloud" }
-jakarta-annotation-api = { module = "jakarta.annotation:jakarta.annotation-api", version.ref = "jakarta-annotation-api" }
+jspecify = { module = "org.jspecify:jspecify", version.ref = "jspecify" }
 coapi-bom = { module = "me.ahoo.coapi:coapi-bom", version.ref = "coapi" }
 axon-bom = { module = "org.axonframework:axon-bom", version.ref = "axon" }
 testcontainers-bom = { module = "org.testcontainers:testcontainers-bom", version.ref = "testcontainers" }

--- a/proxy/cosid-proxy-api/src/main/java/me/ahoo/cosid/proxy/api/ErrorResponse.java
+++ b/proxy/cosid-proxy-api/src/main/java/me/ahoo/cosid/proxy/api/ErrorResponse.java
@@ -15,7 +15,7 @@ package me.ahoo.cosid.proxy.api;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import jakarta.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
 
 import java.util.Collections;
 import java.util.List;

--- a/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/ProxyIdSegmentDistributor.java
+++ b/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/ProxyIdSegmentDistributor.java
@@ -18,7 +18,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * ProxyIdSegmentDistributor .
@@ -41,13 +41,13 @@ public class ProxyIdSegmentDistributor implements IdSegmentDistributor {
         this.step = step;
     }
     
-    @Nonnull
+    @NonNull
     @Override
     public String getNamespace() {
         return namespace;
     }
     
-    @Nonnull
+    @NonNull
     @Override
     public String getName() {
         return name;

--- a/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/ProxyIdSegmentDistributorFactory.java
+++ b/proxy/cosid-proxy/src/main/java/me/ahoo/cosid/proxy/ProxyIdSegmentDistributorFactory.java
@@ -20,7 +20,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
-import jakarta.annotation.Nonnull;
+import org.jspecify.annotations.NonNull;
 
 /**
  * ProxyIdSegmentDistributorFactory .
@@ -37,7 +37,7 @@ public class ProxyIdSegmentDistributorFactory implements IdSegmentDistributorFac
         this.segmentClient = segmentClient;
     }
 
-    @Nonnull
+    @NonNull
     @SneakyThrows
     @Override
     public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {


### PR DESCRIPTION
- Replace jakarta.annotation.Nonnull with org.jspecify.annotations.NonNull
- Replace jakarta.annotation.Nullable with org.jspecify.annotations.Nullable
- Update build.gradle.kts to use jspecify dependency instead of jakarta.annotation.api
- Update libs.versions.toml to reference jspecify version 1.0.0
- Apply jspecify annotations consistently across all affected classes
- Remove deprecated jakarta annotation imports from all files
