### PR TITLE
docs: optimize CosId skills

### DIFF
--- a/skills/cosid-manual-integration/SKILL.md
+++ b/skills/cosid-manual-integration/SKILL.md
@@ -53,7 +53,15 @@ Always define the namespace and instance identity deliberately. For production, 
 MachineIdDistributor distributor = createMachineIdDistributor();
 
 // 2. Allocate machine ID
-int machineId = distributor.distribute("my-namespace", instanceId, Duration.ofSeconds(10));
+int machineBit = 10;
+InstanceId instanceId = InstanceId.of("order-service-0", true);
+MachineState machineState = distributor.distribute(
+    "my-namespace",
+    machineBit,
+    instanceId,
+    Duration.ofSeconds(10)
+);
+int machineId = machineState.getMachineId();
 
 // 3. Create SnowflakeId
 SnowflakeId snowflakeId = new MillisecondSnowflakeId(machineId);

--- a/skills/cosid-manual-integration/SKILL.md
+++ b/skills/cosid-manual-integration/SKILL.md
@@ -1,21 +1,21 @@
 ---
 name: cosid-manual-integration
-description: Guide for manually integrating CosId into Java/Kotlin projects without Spring Boot auto-configuration. Use this skill when the user wants to configure CosId programmatically, set up custom ID generators, integrate CosId in non-Spring environments, asks about CosId core API usage (SnowflakeId, SegmentId, CosIdGenerator), needs to configure machine ID allocation manually, or mentions "manual integration", "programmatic configuration", "without Spring Boot", "non-Spring environment", or "library integration".
+description: Manually integrate CosId into Java or Kotlin applications without Spring Boot auto-configuration. Use when the user needs programmatic setup for SnowflakeId, SegmentId, SegmentChainId, CosIdGenerator, machine ID distribution, custom IdConverter wiring, non-Spring environments, library/framework integration, or production-safe generator lifecycle management.
 ---
 
 # CosId Manual Integration Skill
 
-## Instructions
+Use this skill when CosId must be configured with code instead of `cosid-spring-boot-starter`.
 
-### When to Use
+## Workflow
 
-- User wants to integrate CosId without Spring Boot
-- User needs custom programmatic configuration of ID generators
-- User is building a library or framework that needs ID generation
-- User asks about CosId core API usage (SnowflakeId, SegmentId, CosIdGenerator)
-- User needs to configure machine ID allocation manually
+1. Identify the generator strategy. Use `$cosid-strategy-guide` first if the user has not chosen one.
+2. Identify the coordination mechanism: manual machine ID, StatefulSet ordinal, Redis, JDBC, MongoDB, ZooKeeper, or proxy.
+3. Show the minimal constructor/wiring path for the chosen generator.
+4. Include lifecycle handling for distributors, guard/heartbeat, prefetch workers, and state storage when relevant.
+5. Add a small verification example: uniqueness, monotonicity, parser behavior, or restart behavior.
 
-### Core Architecture
+## Core APIs
 
 CosId provides three main ID generation strategies:
 
@@ -33,22 +33,24 @@ CosId provides three main ID generation strategies:
    - Requires `MachineIdDistributor` for machine ID allocation (same as SnowflakeId)
    - Supports much larger instance counts than SnowflakeId (not constrained by 63-bit long format)
 
-### Machine ID Allocation
+## Machine ID Allocation
 
 For SnowflakeId, each instance needs a unique machineId. Options:
 
 - **Manual**: Set machineId directly (0-1023 for default 10-bit)
-- **Redis**: `RedisMachineIdDistributor` - uses Redis for coordination
+- **Redis**: `SpringRedisMachineIdDistributor` - uses Redis for coordination
 - **JDBC**: `JdbcMachineIdDistributor` - uses database table
 - **ZooKeeper**: `ZookeeperMachineIdDistributor` - uses ZK nodes
 - **MongoDB**: `MongoMachineIdDistributor` - uses MongoDB collection
 - **StatefulSet**: Kubernetes StatefulSet ordinal as machineId
 
-### Manual Configuration Pattern
+Always define the namespace and instance identity deliberately. For production, prefer a distributor that can guard ownership and reclaim expired machine IDs.
+
+## SnowflakeId Configuration Pattern
 
 ```java
-// 1. Create machine ID distributor
-MachineIdDistributor distributor = new RedisMachineIdDistributor(redisTemplate);
+// 1. Create a backend-specific MachineIdDistributor
+MachineIdDistributor distributor = createMachineIdDistributor();
 
 // 2. Allocate machine ID
 int machineId = distributor.distribute("my-namespace", instanceId, Duration.ofSeconds(10));
@@ -63,7 +65,34 @@ SnowflakeId safeId = new ClockSyncSnowflakeId(snowflakeId);
 long id = safeId.generate();
 ```
 
-### Key Configuration Parameters
+If the user has fixed deployment slots, use `ManualMachineIdDistributor` or directly provide the machine ID, but warn that duplicate machine IDs can create duplicate IDs.
+
+## Segment Configuration Pattern
+
+Use `SegmentId` or `SegmentChainId` when monotonic IDs and batch allocation are more important than time-encoded IDs.
+
+```java
+IdSegmentDistributor distributor = createIdSegmentDistributor("order_id", 100);
+SegmentChainId idGenerator = new SegmentChainId(distributor);
+
+long id = idGenerator.generate();
+String text = idGenerator.generateAsString();
+```
+
+For `SegmentChainId`, ensure the prefetch worker lifecycle is owned by the application and is closed during shutdown if the concrete setup exposes close/shutdown behavior.
+
+## CosIdGenerator Pattern
+
+Use `CosIdGenerator` when callers need compact string IDs rather than `long` IDs.
+
+```java
+CosIdGenerator generator = new Radix62CosIdGenerator(machineId);
+String id = generator.generateAsString();
+```
+
+Wrap with the clock-sync variant when system clock drift is a production concern.
+
+## Key Parameters
 
 | Parameter | Default | Description |
 |-----------|---------|-------------|
@@ -73,14 +102,16 @@ long id = safeId.generate();
 | sequenceBit | 12 (ms) / 22 (s) | IDs per time unit per machine |
 | clockSync | true | Enable clock backwards synchronization |
 
-### Common Pitfalls
+## Common Pitfalls
 
 - **Clock backwards**: Always use `ClockSyncSnowflakeId` wrapper in production
 - **Machine ID overflow**: With 10 bits, max 1024 instances per namespace
 - **Sequence exhaustion**: High throughput may need `SecondSnowflakeId` (4M/s/machine) over millisecond variant (4K/s/machine)
 - **JavaScript safety**: Use `SafeJavaScriptSnowflakeId` if IDs go to frontend
+- **Lifecycle leaks**: Close distributor clients and background workers when the application shuts down
+- **State loss**: Persist machine state when restart stability matters
 
-### Testing Configuration
+## Testing Configuration
 
 For tests, use `ManualMachineIdDistributor` with fixed machine IDs:
 
@@ -88,7 +119,15 @@ For tests, use `ManualMachineIdDistributor` with fixed machine IDs:
 MachineIdDistributor distributor = new ManualMachineIdDistributor(1);
 ```
 
-## References
+Add tests for the property that matters in the user's case:
+
+- Uniqueness across concurrent generation
+- Local monotonicity for SegmentId/SegmentChainId
+- Time parser correctness for SnowflakeId
+- JavaScript-safe range or string conversion
+- Machine ID conflict behavior when manual IDs are used
+
+## Source Pointers
 
 - Source: `cosid-core/src/main/java/me/ahoo/cosid/`
 - Examples: `examples/` directory

--- a/skills/cosid-manual-integration/agents/openai.yaml
+++ b/skills/cosid-manual-integration/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CosId Manual Integration"
+  short_description: "Integrate CosId without Spring Boot"
+  default_prompt: "Use $cosid-manual-integration to wire CosId programmatically without Spring Boot."

--- a/skills/cosid-sharding/SKILL.md
+++ b/skills/cosid-sharding/SKILL.md
@@ -240,7 +240,7 @@ Use a small routing matrix before finalizing a rule:
 
 1. **Precise + Range**: Every algorithm supports both single-value and range sharding. ShardingSphere uses precise for `=` and `IN`, and range for `BETWEEN`, `>`, `<`.
 2. **Effective nodes**: `getEffectiveNodes()` returns all possible target nodes. This is used by ShardingSphere for routing optimization.
-3. **Thread safety**: All sharding implementations are thread-safe (`@ThreadSafe`).
+3. **Thread safety**: The `Sharding` interface is annotated `@ThreadSafe`; implementations follow that contract, but not every concrete class repeats the annotation.
 4. **Interval bounds**: `IntervalTimeline` requires an explicit effective time range. Values outside this range throw `IllegalArgumentException`.
 5. **Generator alignment**: When the sharding key is a CosId-generated ID, keep the generator epoch, timestamp unit, and converter settings aligned with the sharding rule.
 

--- a/skills/cosid-sharding/SKILL.md
+++ b/skills/cosid-sharding/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: cosid-sharding
-description: Guide for using CosId sharding algorithms for database sharding with ShardingSphere. Use this skill whenever the user mentions database sharding, table sharding, ShardingSphere, interval sharding, modulo sharding, date-based sharding, range sharding, or needs to distribute data across multiple database tables or nodes. Also use when the user asks about ModCycle, IntervalTimeline, CachedSharding, PreciseSharding, RangeSharding, or SnowflakeLocalDateTimeConvertor.
+description: Design and configure CosId sharding algorithms for database sharding and ShardingSphere. Use when the user mentions table or database sharding, ShardingSphere COSID_MOD or COSID_INTERVAL rules, modulo sharding, date/time interval sharding, range routing, SnowflakeId timestamp extraction, ModCycle, IntervalTimeline, CachedSharding, PreciseSharding, RangeSharding, or SnowflakeLocalDateTimeConvertor.
 ---
 
 # CosId Sharding Algorithms
 
-CosId provides sharding algorithms designed for database sharding, compatible with Apache ShardingSphere. All algorithms implement both precise sharding (single key lookup) and range sharding (key range lookup).
+Use this skill to choose, configure, and validate CosId sharding behavior.
+
+## Workflow
+
+1. Identify the sharding key type: numeric ID, SnowflakeId, `LocalDateTime`, or an existing timestamp column.
+2. Choose the algorithm: `ModCycle` for uniform numeric distribution, `IntervalTimeline` for time ranges, or `CachedSharding` to cache repeated range routing.
+3. Confirm both precise and range queries. ShardingSphere routes `=`, `IN`, and range predicates differently.
+4. Define effective nodes and bounds explicitly. For interval sharding, include lower/upper datetime bounds and suffix format.
+5. Provide a minimal Java or ShardingSphere YAML example and a routing test.
 
 ## Sharding Algorithm Types
 
@@ -33,6 +41,8 @@ Implementations:
 ## ModCycle - Modulo Sharding
 
 Distributes numeric IDs across nodes using `value % divisor`. Best for uniform distribution when using SnowflakeId or SegmentId.
+
+Use `ModCycle` when the sharding key is already numeric and the desired distribution is even across a fixed number of tables or databases.
 
 ### Usage
 
@@ -74,6 +84,8 @@ rules:
 ## IntervalTimeline - Time-Based Sharding
 
 Distributes data across time-based intervals. Each interval maps to a specific node named with a formatted date suffix.
+
+Use `IntervalTimeline` when table names encode time periods such as day, month, or hour. It is also appropriate when a SnowflakeId can be converted back into event time.
 
 ### Usage
 
@@ -213,12 +225,30 @@ Range queries are often repeated (e.g., querying "last 7 days" across many reque
 | High QPS range queries | CachedSharding + any | Cache avoids recomputation |
 | Auto-increment / SegmentId as key | ModCycle | Even distribution of monotonic IDs |
 
+## Validation Checklist
+
+Use a small routing matrix before finalizing a rule:
+
+- One exact key routes to exactly one expected node.
+- An `IN` query routes to the union of expected nodes.
+- A range query covers all boundary nodes and no unrelated nodes when possible.
+- Values outside an `IntervalTimeline` effective range fail intentionally.
+- Snowflake timestamp extraction uses the same epoch and timestamp bits as the generator.
+- The ShardingSphere `actualDataNodes` expression matches every possible CosId effective node.
+
 ## Key Design Principles
 
 1. **Precise + Range**: Every algorithm supports both single-value and range sharding. ShardingSphere uses precise for `=` and `IN`, and range for `BETWEEN`, `>`, `<`.
-
 2. **Effective nodes**: `getEffectiveNodes()` returns all possible target nodes. This is used by ShardingSphere for routing optimization.
-
 3. **Thread safety**: All sharding implementations are thread-safe (`@ThreadSafe`).
+4. **Interval bounds**: `IntervalTimeline` requires an explicit effective time range. Values outside this range throw `IllegalArgumentException`.
+5. **Generator alignment**: When the sharding key is a CosId-generated ID, keep the generator epoch, timestamp unit, and converter settings aligned with the sharding rule.
 
-4. **Interval bounds**: IntervalTimeline requires an explicit effective time range. Values outside this range throw `IllegalArgumentException`.
+## Response Template
+
+When answering a sharding request, include:
+
+1. The selected algorithm and why it fits the sharding key.
+2. The expected table/database naming pattern.
+3. A concise Java or ShardingSphere YAML example.
+4. A routing test matrix for exact, `IN`, and range queries.

--- a/skills/cosid-sharding/agents/openai.yaml
+++ b/skills/cosid-sharding/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CosId Sharding"
+  short_description: "Design CosId ShardingSphere rules"
+  default_prompt: "Use $cosid-sharding to design CosId sharding rules for my database tables."

--- a/skills/cosid-spring-boot/SKILL.md
+++ b/skills/cosid-spring-boot/SKILL.md
@@ -18,22 +18,23 @@ CosId is a universal, flexible, high-performance distributed ID generator for Ja
 
 ## Dependency Setup
 
-Add the BOM and starter to your `build.gradle`:
+Add the BOM and starter to your Gradle build. When you need a distributor backend, select the corresponding Gradle feature capability:
 
 ```groovy
 dependencies {
     implementation platform("me.ahoo.cosid:cosid-bom:${cosidVersion}")
-    implementation "me.ahoo.cosid:cosid-spring-boot-starter"
-    
-    // Add the distributor backend needed by your infrastructure:
-    implementation "me.ahoo.cosid:cosid-spring-boot-starter:springRedisSupport"  // Redis
-    // implementation "me.ahoo.cosid:cosid-spring-boot-starter:jdbcSupport"     // JDBC/MySQL
-    // implementation "me.ahoo.cosid:cosid-spring-boot-starter:mongoSupport"    // MongoDB
-    // implementation "me.ahoo.cosid:cosid-spring-boot-starter:zookeeperSupport" // ZooKeeper
+
+    // Redis backend. Replace the capability with jdbc-support, mongo-support,
+    // zookeeper-support, proxy-support, actuator-support, etc. as needed.
+    implementation("me.ahoo.cosid:cosid-spring-boot-starter") {
+        capabilities {
+            requireCapability("me.ahoo.cosid:spring-redis-support")
+        }
+    }
 }
 ```
 
-Or with Maven:
+For Maven, import the BOM and add the starter plus the backend module explicitly:
 
 ```xml
 <dependencyManagement>
@@ -53,11 +54,10 @@ Or with Maven:
         <groupId>me.ahoo.cosid</groupId>
         <artifactId>cosid-spring-boot-starter</artifactId>
     </dependency>
-    <!-- Redis variant -->
+    <!-- Redis backend. Use cosid-jdbc, cosid-mongo, or cosid-zookeeper for other backends. -->
     <dependency>
         <groupId>me.ahoo.cosid</groupId>
-        <artifactId>cosid-spring-boot-starter</artifactId>
-        <classifier>springRedisSupport</classifier>
+        <artifactId>cosid-spring-redis</artifactId>
     </dependency>
 </dependencies>
 ```

--- a/skills/cosid-spring-boot/SKILL.md
+++ b/skills/cosid-spring-boot/SKILL.md
@@ -1,11 +1,20 @@
 ---
 name: cosid-spring-boot
-description: Guide for integrating CosId distributed ID generator with Spring Boot. Use this skill whenever the user mentions CosId, distributed ID generation, SnowflakeId, SegmentId, SegmentChainId, CosIdGenerator, machine ID allocation, or needs help configuring ID generation in a Spring Boot application. Also use when the user asks about ID conversion (Radix62, Radix36, SnowflakeFriendly), sharding with CosId, or configuring machine ID distributors (Redis, JDBC, MongoDB, ZooKeeper) for Spring Boot. Triggers on cosid YAML configuration, application.yml ID setup, or any CosId Spring Boot starter questions.
+description: Configure CosId in Spring Boot applications with cosid-spring-boot-starter. Use when the user works with application.yml, Gradle or Maven dependencies, starter feature variants, Redis/JDBC/MongoDB/ZooKeeper/proxy distributors, SnowflakeId, SegmentId, SegmentChainId, CosIdGenerator, @CosId, IdGeneratorProvider, ID converters, machine guarder settings, clock-backwards synchronization, or Actuator endpoints in a Spring Boot service.
 ---
 
 # CosId Spring Boot Integration
 
 CosId is a universal, flexible, high-performance distributed ID generator for Java 17+. The Spring Boot starter (`cosid-spring-boot-starter`) provides auto-configuration for all ID generation strategies.
+
+## Workflow
+
+1. Confirm the user's Spring Boot and CosId major versions. CosId 2.x targets Spring Boot 3.x and Java 17; CosId 3.x targets Spring Boot 4.x and Java 17.
+2. Choose the ID strategy. Use `$cosid-strategy-guide` first when the user has not chosen between SnowflakeId, SegmentId, SegmentChainId, and CosIdGenerator.
+3. Select the distributor and starter capability needed by the deployment: Redis, JDBC, MongoDB, ZooKeeper, proxy, manual, or StatefulSet.
+4. Provide the smallest working YAML for the selected strategy and backend.
+5. Show how the application consumes the generator: shared bean, named provider, or `@CosId`.
+6. Add validation guidance for uniqueness, ordering, machine ID ownership, segment allocation, and Actuator visibility.
 
 ## Dependency Setup
 
@@ -16,7 +25,7 @@ dependencies {
     implementation platform("me.ahoo.cosid:cosid-bom:${cosidVersion}")
     implementation "me.ahoo.cosid:cosid-spring-boot-starter"
     
-    // Add exactly ONE distributor backend based on your infrastructure:
+    // Add the distributor backend needed by your infrastructure:
     implementation "me.ahoo.cosid:cosid-spring-boot-starter:springRedisSupport"  // Redis
     // implementation "me.ahoo.cosid:cosid-spring-boot-starter:jdbcSupport"     // JDBC/MySQL
     // implementation "me.ahoo.cosid:cosid-spring-boot-starter:mongoSupport"    // MongoDB
@@ -68,8 +77,9 @@ There are 4 ID generation strategies in CosId. The right choice depends on your 
 
 - **Need maximum performance and have Redis/JDBC available?** → SegmentChainId (default segment mode)
 - **Need time-sortable IDs across machines?** → SnowflakeId
-- **Simple standalone app?** → CosIdGenerator (no external dependencies)
+- **Need compact string IDs or a large machine-ID design space?** → CosIdGenerator
 - **Database-friendly monotonic IDs?** → SegmentId or SegmentChainId
+- **Need only strategy selection?** → Use `$cosid-strategy-guide` before writing YAML
 
 ## Configuration Templates
 
@@ -459,3 +469,23 @@ management:
 ```
 
 The `cosid` endpoint shows all registered ID generators and their stats.
+
+## Validation Checklist
+
+- Run a focused Spring Boot test that loads the application context with the chosen backend capability.
+- Generate IDs concurrently and assert uniqueness.
+- For SnowflakeId, verify machine ID allocation and clock-backwards settings.
+- For SegmentId/SegmentChainId, verify the segment distributor initializes the `cosid` table or backend state.
+- For converters, assert the expected prefix, padding, radix, and string length.
+- For shared beans, assert `IdGenerator` or `StringIdGenerator` resolves to the intended provider.
+- For production services, expose and inspect the CosId Actuator endpoint when actuator support is enabled.
+
+## Response Template
+
+When answering a Spring Boot integration request, include:
+
+1. Dependency coordinates and the required backend capability.
+2. Minimal `application.yml` for the selected generator.
+3. Code snippet for injection or `@CosId`.
+4. Operational notes for machine ID, clock, state storage, and monitoring.
+5. A small test or verification command the user can run.

--- a/skills/cosid-spring-boot/agents/openai.yaml
+++ b/skills/cosid-spring-boot/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CosId Spring Boot"
+  short_description: "Configure CosId Spring Boot starter"
+  default_prompt: "Use $cosid-spring-boot to configure CosId in my Spring Boot application."

--- a/skills/cosid-strategy-guide/SKILL.md
+++ b/skills/cosid-strategy-guide/SKILL.md
@@ -1,11 +1,19 @@
 ---
 name: cosid-strategy-guide
-description: Guide for choosing the right CosId ID generation strategy. Use this skill whenever the user is unsure which CosId ID generator to use, asks about SnowflakeId vs SegmentId vs SegmentChainId vs CosIdGenerator, or needs help selecting a distributed ID strategy. Also use when the user mentions ID throughput, monotonic IDs, time-ordered IDs, machine ID allocation, or asks "which ID generator should I use" in the context of distributed systems or CosId.
+description: Choose the right CosId ID generation strategy for Java distributed systems. Use when the user compares CosIdGenerator, SnowflakeId, SegmentId, or SegmentChainId; asks which generator to use; or evaluates ID type, ordering, throughput, clock sensitivity, machine ID allocation, JavaScript-safe IDs, coordination backends, or production tradeoffs.
 ---
 
 # CosId ID Strategy Selection Guide
 
-CosId provides 4 ID generation strategies, each designed for different use cases. This guide helps you choose the right one.
+Use this skill to turn requirements into a concrete CosId generator recommendation.
+
+## Workflow
+
+1. Identify the constraints: required ID type (`long`, `String`, or both), ordering semantics, peak QPS, cluster size, JavaScript exposure, acceptable gaps, available infrastructure, and whether IDs must encode time.
+2. Recommend one primary strategy and, when useful, one fallback.
+3. Explain the operational cost: clock behavior, external coordination, machine ID lifecycle, segment gaps, restart behavior, and tuning knobs.
+4. Hand off to `$cosid-spring-boot` for Spring Boot YAML or `$cosid-manual-integration` for programmatic setup.
+5. Include a small configuration sketch only when the user needs implementation detail.
 
 ## Strategy Comparison
 
@@ -19,26 +27,21 @@ CosId provides 4 ID generation strategies, each designed for different use cases
 | **Clock Sensitive** | Yes | Yes | No | No |
 | **Max Instances** | 2^machineBit | 2^machineBit | Unlimited | Unlimited |
 
-## Decision Tree
+## Recommendation Rules
 
-```
-Need distributed IDs?
-└── Yes
-    ├── Need time-sortable long IDs?
-    │   └── Yes → SnowflakeId (max instances limited by machineBit, typically 1024)
-    └── No time-sortable requirement
-        ├── Large-scale cluster (超过 SnowflakeId 实例限制)?
-        │   └── Yes → CosIdGenerator (String IDs, 全局唯一, 支持超大规模集群)
-        └── Need maximum throughput?
-            └── Yes → SegmentChainId
-            └── No → SegmentId (simpler)
-```
+- Use `SegmentChainId` as the default production recommendation when the system can use Redis, JDBC, MongoDB, ZooKeeper, or the proxy distributor and needs high-throughput monotonic IDs.
+- Use `SnowflakeId` when callers need `long` IDs that are roughly time ordered or must be parsed back into timestamp, machine ID, and sequence.
+- Use `SegmentId` when the team wants monotonic IDs with simpler behavior than `SegmentChainId` and can tolerate fetching a new segment synchronously when the current segment is exhausted.
+- Use `CosIdGenerator` when compact `String` IDs are acceptable and the deployment needs a larger design space than the 63-bit Snowflake layout.
+- Use manual or StatefulSet machine ID allocation only when instance identities are fixed and operationally controlled.
+- Prefer Redis for low-latency coordination when it already exists; prefer JDBC when the platform already depends on a relational database and wants fewer moving parts.
+- For JavaScript clients, return strings or wrap Snowflake with `SafeJavaScriptSnowflakeId` when numeric precision matters.
 
 ## Strategy Details
 
-### 1. CosIdGenerator — Large-Scale Cluster String IDs
+### CosIdGenerator: Large-Scale String IDs
 
-A state-based ID generator designed for large-scale clusters that exceed SnowflakeId's machine bit limit. Produces compact string IDs with globally unique guarantees. Like SnowflakeId, it requires a `MachineIdDistributor` to assign unique machine IDs to each instance, but it is not constrained by the 63-bit long format, allowing it to support a much larger number of instances.
+Produces compact string IDs and is useful when a `long` ID format is not required.
 
 **When to use:**
 - Large-scale clusters that exceed SnowflakeId's machine bit limit (typically 1024 instances)
@@ -57,28 +60,9 @@ A state-based ID generator designed for large-scale clusters that exceed Snowfla
 - `FriendlyCosIdGenerator` — Human-readable format
 - `ClockSyncCosIdGenerator` — Wraps any CosIdGenerator with clock sync
 
-**Spring Boot config:**
+### SnowflakeId: Time-Ordered Distributed Long IDs
 
-```yaml
-cosid:
-  machine:
-    enabled: true
-    distributor:
-      type: redis  # or jdbc, mongo, zookeeper, manual, stateful_set
-  generator:
-    enabled: true
-```
-
-**Programmatic usage:**
-
-```java
-CosIdGenerator generator = new Radix62CosIdGenerator(machineId);
-String id = generator.generateAsString();
-```
-
-### 2. SnowflakeId — Time-Ordered Distributed IDs
-
-The Twitter Snowflake algorithm. Generates 63-bit `long` IDs composed of timestamp + machineId + sequence.
+Generates 63-bit `long` IDs composed of timestamp, machine ID, and sequence.
 
 **When to use:**
 - Need time-sortable IDs (IDs roughly reflect creation time)
@@ -112,25 +96,11 @@ cosid:
 
 **Important constraint:** `timestampBit + machineBit + sequenceBit = 63` (63 because the sign bit is reserved).
 
-**JavaScript-safe IDs:** JavaScript's `Number.MAX_SAFE_INTEGER` is 2^53 - 1. If your SnowflakeId exceeds this, use `SafeJavaScriptSnowflakeId` to constrain the bit layout automatically.
-
-**Clock backwards handling:** SnowflakeId is sensitive to system clock changes. CosId provides `ClockSyncSnowflakeId` that wraps any SnowflakeId with clock drift tolerance:
+**Clock backwards handling:** SnowflakeId is sensitive to system clock changes. Use `ClockSyncSnowflakeId` or Spring Boot clock-backwards settings for production:
 - Small drift (< `spinThreshold`): Spin-wait until time catches up
 - Large drift (> `brokenThreshold`): Throw `ClockTooManyBackwardsException`
 
-**Spring Boot config:**
-
-```yaml
-cosid:
-  machine:
-    enabled: true
-    distributor:
-      type: redis  # or jdbc, mongo, zookeeper, manual, stateful_set
-  snowflake:
-    enabled: true
-```
-
-### 3. SegmentId — Monotonic IDs with Batch Allocation
+### SegmentId: Monotonic IDs with Batch Allocation
 
 Allocates IDs in contiguous segments (batches) to reduce network I/O. Each instance gets a range of IDs and serves them locally.
 
@@ -165,11 +135,11 @@ cosid:
 ```
 
 **Tuning the `step` parameter:**
-- Larger step → fewer network calls, but more ID gaps on restart
-- Smaller step → fewer wasted IDs, but more coordination overhead
+- Larger step: fewer network calls, but more ID gaps on restart
+- Smaller step: fewer wasted IDs, but more coordination overhead
 - Start with `step: 100` for moderate workloads, increase to `1000+` for high QPS
 
-### 4. SegmentChainId — Maximum Throughput (Recommended)
+### SegmentChainId: Maximum Throughput
 
 An enhancement of SegmentId that chains multiple segments with lock-free prefetching. This is the highest-throughput ID generator in CosId.
 
@@ -191,25 +161,6 @@ SegmentChainId: [current] → [prefetched] → [prefetched] → (background pref
 The prefetch distance adapts dynamically:
 - **High demand** (hungry): Distance doubles (up to 100M)
 - **Low demand** (full): Distance halves (down to `safeDistance`)
-
-**Spring Boot config:**
-
-```yaml
-cosid:
-  segment:
-    enabled: true
-    mode: chain       # ← chain mode enables SegmentChainId
-    distributor:
-      type: redis
-    chain:
-      safe-distance: 2            # minimum prefetched segments
-      prefetch-worker:
-        prefetch-period: 1000ms   # how often to check prefetch
-        core-pool-size: 8         # prefetch thread pool size
-    provider:
-      order_id:
-        step: 100
-```
 
 ## Distributor Backends
 
@@ -321,3 +272,12 @@ cosid:
     distributor:
       type: redis
 ```
+
+## Response Template
+
+When answering a strategy question, use this structure:
+
+1. Recommendation: name the generator and why it matches the constraints.
+2. Tradeoffs: call out ordering, throughput, clock sensitivity, coordination, and restart gaps.
+3. Configuration direction: name the distributor backend and whether Spring Boot or manual setup is appropriate.
+4. Validation: suggest a focused test or benchmark for the user's actual throughput and ordering requirement.

--- a/skills/cosid-strategy-guide/agents/openai.yaml
+++ b/skills/cosid-strategy-guide/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "CosId Strategy Guide"
+  short_description: "Choose CosId ID generation strategies"
+  default_prompt: "Use $cosid-strategy-guide to recommend the right CosId ID generation strategy for my system."

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -1,0 +1,40 @@
+{
+  "schemaVersion": 1,
+  "plugins": [
+    {
+      "name": "ahoo-cosid-skills",
+      "description": "CosId skills for choosing and integrating high-performance distributed ID generators, Spring Boot auto-configuration, machine ID distributors, and ShardingSphere sharding.",
+      "skills": {
+        "include": [
+          "*"
+        ],
+        "exclude": [
+          "*-workspace"
+        ]
+      },
+      "keywords": [
+        "cosid",
+        "distributed-id",
+        "snowflake",
+        "segment-id",
+        "segment-chain-id",
+        "machine-id",
+        "sharding",
+        "spring-boot",
+        "java"
+      ],
+      "category": "development",
+      "interface": {
+        "displayName": "Ahoo CosId Skills",
+        "capabilities": [
+          "Skills"
+        ],
+        "defaultPrompt": "Help me choose and integrate CosId distributed ID generation strategies, Spring Boot configuration, machine ID distributors, and ShardingSphere sharding."
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Optimize CosId skill trigger metadata and execution workflows for strategy selection, Spring Boot integration, manual integration, and sharding guidance.
- Add `agents/openai.yaml` metadata for each skill so marketplace/UI surfaces have display names, short descriptions, and default prompts.
- Add platform-neutral `skills/plugins.json` declaring the `ahoo-cosid-skills` plugin while excluding `*-workspace` skills.

## Validation

- `uv run --with pyyaml python /Users/ahoo/.codex/skills/.system/skill-creator/scripts/quick_validate.py` for all four CosId skills
- `jq -e` validation for `skills/plugins.json` schema, plugin name, and include/exclude rules
- YAML parse check for all four `skills/*/agents/openai.yaml` files