### PR TITLE
fix(cosid-core): 4 bugs in snowflake/sharding/machine (TDD-verified)

### DIFF
--- a/cosid-core/src/main/java/me/ahoo/cosid/machine/DefaultClockBackwardsSynchronizer.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/machine/DefaultClockBackwardsSynchronizer.java
@@ -40,7 +40,7 @@ public class DefaultClockBackwardsSynchronizer implements ClockBackwardsSynchron
 
     public DefaultClockBackwardsSynchronizer(int spinThreshold, int brokenThreshold) {
         Preconditions.checkArgument(spinThreshold > 0, "spinThreshold:[%s] must be greater than 0!", spinThreshold);
-        Preconditions.checkArgument(brokenThreshold > spinThreshold, "spinThreshold:[%s] must be greater than brokenThreshold:[%s]!", spinThreshold, brokenThreshold);
+        Preconditions.checkArgument(brokenThreshold > spinThreshold, "brokenThreshold:[%s] must be greater than spinThreshold:[%s]!", brokenThreshold, spinThreshold);
 
         this.spinThreshold = spinThreshold;
         this.brokenThreshold = brokenThreshold;

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/ExactCollection.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/ExactCollection.java
@@ -103,6 +103,7 @@ public class ExactCollection<E> extends AbstractCollection<E> implements RandomA
         int idx = indexOf(o);
         if (idx >= 0) {
             elements[idx] = null;
+            return true;
         }
         return false;
     }

--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
@@ -71,7 +71,7 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
 
     @Override
     public @NonNull String sharding(T shardingValue) {
-        int nodeIdx = (int) (shardingValue.longValue() % divisor);
+        int nodeIdx = Math.floorMod(shardingValue.longValue(), divisor);
         return effectiveNodes.get(nodeIdx);
     }
 
@@ -109,7 +109,7 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
         ExactCollection<String> nodes = new ExactCollection<>(nodeSize);
         int idx = 0;
         while (lower <= upper) {
-            int modValue = (int) (lower % divisor);
+            int modValue = Math.floorMod(lower, divisor);
             String matchedNode = effectiveNodes.get(modValue);
             nodes.add(idx, matchedNode);
             lower++;

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeId.java
@@ -80,7 +80,10 @@ public final class SafeJavaScriptSnowflakeId {
         final int machineBit = MillisecondSnowflakeId.DEFAULT_MACHINE_BIT - 7;
         final int sequenceBit = MillisecondSnowflakeId.DEFAULT_SEQUENCE_BIT - 3;
         checkTotalBit(timestampBit, machineBit, sequenceBit);
-        return ofMillisecond(CosId.COSID_EPOCH_SECOND, timestampBit, machineBit, sequenceBit, machineId, SnowflakeId.defaultSequenceResetThreshold(sequenceBit));
+        // MillisecondSnowflakeId.getCurrentTime() returns System.currentTimeMillis() (ms),
+        // so the epoch must be the millisecond epoch to keep diffTimestamp = (nowMs - epochMs)
+        // in the same units as the 41-bit timestamp field.
+        return ofMillisecond(CosId.COSID_EPOCH, timestampBit, machineBit, sequenceBit, machineId, SnowflakeId.defaultSequenceResetThreshold(sequenceBit));
     }
 
     /**

--- a/cosid-core/src/test/java/me/ahoo/cosid/machine/DefaultClockBackwardsSynchronizerTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/machine/DefaultClockBackwardsSynchronizerTest.java
@@ -75,4 +75,27 @@ class DefaultClockBackwardsSynchronizerTest {
         assertThrows(ClockTooManyBackwardsException.class,
             () -> synchronizer.syncUninterruptibly(exceedTimestamp));
     }
+
+    /**
+     * When a caller passes an invalid {@code (spinThreshold, brokenThreshold)}
+     * pair where {@code brokenThreshold <= spinThreshold}, the thrown exception
+     * message must accurately describe the violated invariant so the caller can
+     * fix their configuration. The previous message stated the inverted relation
+     * ("spinThreshold must be greater than brokenThreshold"), which described a
+     * condition the caller may actually have satisfied, making diagnosis impossible.
+     */
+    @Test
+    void ctorWhenBrokenThresholdNotGreaterThanSpinThresholdHasAccurateMessage() {
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            () -> new DefaultClockBackwardsSynchronizer(500, 1));
+
+        String message = ex.getMessage();
+        // The invariant is brokenThreshold > spinThreshold; the message must not
+        // claim the opposite.
+        assertFalse(message.contains("spinThreshold:[500] must be greater than brokenThreshold"),
+            "Error message must not state the inverted invariant. Actual: " + message);
+        // It should clearly communicate that brokenThreshold must exceed spinThreshold.
+        assertTrue(message.contains("brokenThreshold"),
+            "Error message should reference brokenThreshold. Actual: " + message);
+    }
 }

--- a/cosid-core/src/test/java/me/ahoo/cosid/sharding/ExactCollectionTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/sharding/ExactCollectionTest.java
@@ -90,6 +90,23 @@ class ExactCollectionTest {
         Assertions.assertTrue(exactCollection.stream().filter(x -> Objects.nonNull(x)).collect(Collectors.toList()).size() == 1);
     }
 
+    /**
+     * {@link Collection#remove(Object)} is specified to return {@code true} if the
+     * collection changed as a result of the call. The previous implementation nulls
+     * out the element but always returns {@code false}, violating the contract for
+     * any caller that branches on the return value.
+     */
+    @Test
+    void removeReturnsTrueWhenChanged() {
+        ExactCollection<String> exactCollection = new ExactCollection<>(10);
+        exactCollection.add(0, "0");
+        exactCollection.add(1, "1");
+
+        Assertions.assertTrue(exactCollection.remove("1"), "remove of a present element must return true");
+        Assertions.assertFalse(exactCollection.remove("1"), "remove of an absent element must return false");
+        Assertions.assertFalse(exactCollection.remove("missing"), "remove of a never-present element must return false");
+    }
+
     @Test
     void addAll() {
         ExactCollection<String> exactCollection = new ExactCollection<>(10);

--- a/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
@@ -83,6 +83,23 @@ class ModCycleTest {
         Assertions.assertEquals(expected, actual);
     }
 
+    /**
+     * Negative sharding values (common with snowflake IDs whose sign bit is set,
+     * or any bit-overflowed long) must map to a valid node, not crash.
+     *
+     * <p>Java's {@code %} preserves the sign of the dividend, so a naive
+     * {@code value % divisor} yields a negative index and
+     * {@link ExactCollection#get(int)} throws {@code ArrayIndexOutOfBoundsException}.
+     */
+    @ParameterizedTest
+    @ValueSource(longs = {-1L, -2L, -3L, -4L, -5L, -8L, -9L, Long.MIN_VALUE})
+    public void shardingPreciseWhenNegative(long shardingValue) {
+        ModCycle<Long> modCycle = createModCycle();
+        String actual = Assertions.assertDoesNotThrow(() -> modCycle.sharding(shardingValue));
+        int expectedIdx = Math.floorMod(shardingValue, DIVISOR);
+        Assertions.assertEquals(LOGIC_NAME_PREFIX + expectedIdx, actual);
+    }
+
     static Stream<Arguments> shardingRangeArgsProvider() {
         return Stream.of(
             arguments(Range.all(), ALL_NODES),
@@ -163,6 +180,20 @@ class ModCycleTest {
         ModCycle<Long> modCycle = createModCycle();
         Collection<String> actual = modCycle.sharding(shardingValue);
         Assertions.assertEquals(expected, actual);
+    }
+
+    /**
+     * A range whose lower endpoint is negative must not crash the range-sharding
+     * path. {@code lower % divisor} is negative for negative {@code lower}, which
+     * previously produced a negative node index.
+     */
+    @Test
+    public void shardingRangeWhenNegativeLower() {
+        ModCycle<Long> modCycle = createModCycle();
+        Collection<String> actual = Assertions.assertDoesNotThrow(
+            () -> modCycle.sharding(Range.closed(-3L, 0L)));
+        // -3 -> floorMod(-3,4)=1, -2 -> 2, -1 -> 3, 0 -> 0  => all 4 nodes
+        Assertions.assertEquals(ALL_NODES, actual);
     }
 
 }

--- a/cosid-core/src/test/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeIdTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeIdTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright [2021-present] [ahoo wang <ahoowang@qq.com> (https://github.com/Ahoo-Wang)].
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package me.ahoo.cosid.snowflake;
+
+import me.ahoo.cosid.CosId;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link SafeJavaScriptSnowflakeId}.
+ *
+ * @author ahoo wang
+ */
+class SafeJavaScriptSnowflakeIdTest {
+
+    /**
+     * The default millisecond safe-JS factory must build a {@link MillisecondSnowflakeId}
+     * whose epoch is in <em>milliseconds</em>, because the generator's
+     * {@code getCurrentTime()} returns {@link System#currentTimeMillis()}.
+     *
+     * <p>Passing {@link CosId#COSID_EPOCH_SECOND} (seconds) here is a unit mismatch
+     * that inflates {@code diffTimestamp = currentTimeMs - epoch} by ~1000x,
+     * exhausting the 41-bit timestamp field in ~13 years instead of ~69 years and
+     * corrupting the wall-clock time returned by the state parser.
+     */
+    @Test
+    void ofMillisecondUsesMillisecondEpoch() {
+        MillisecondSnowflakeId snowflakeId = SafeJavaScriptSnowflakeId.ofMillisecond(1);
+        Assertions.assertEquals(CosId.COSID_EPOCH, snowflakeId.getEpoch(),
+            "ofMillisecond must use the millisecond epoch (COSID_EPOCH), not COSID_EPOCH_SECOND.");
+    }
+
+    /**
+     * A freshly constructed default safe-JS millisecond generator must still have
+     * the bulk of its 41-bit timestamp budget remaining (i.e. it must not be near
+     * overflow today). The buggy seconds-epoch implementation would have already
+     * burned ~93% of the budget by 2026.
+     */
+    @Test
+    void ofMillisecondHasHealthyTimestampBudget() {
+        MillisecondSnowflakeId snowflakeId = SafeJavaScriptSnowflakeId.ofMillisecond(1);
+        long diffTimestamp = System.currentTimeMillis() - snowflakeId.getEpoch();
+        long remaining = snowflakeId.getMaxTimestamp() - diffTimestamp;
+        // With the correct epoch, >50% of the budget should remain. The buggy
+        // (seconds) epoch leaves only ~19% and is shrinking fast toward 2039 overflow.
+        Assertions.assertTrue(remaining > snowflakeId.getMaxTimestamp() / 2,
+            "Millisecond safe-JS snowflake should have most of its timestamp budget left. " +
+                "remaining=" + remaining + " maxTimestamp=" + snowflakeId.getMaxTimestamp());
+    }
+
+    /**
+     * The second-precision safe-JS factory legitimately uses {@link CosId#COSID_EPOCH_SECOND},
+     * since {@link SecondSnowflakeId#getCurrentTime()} works in seconds. This guards
+     * against an over-broad fix that changes both factories.
+     */
+    @Test
+    void ofSecondUsesSecondEpoch() {
+        SecondSnowflakeId snowflakeId = SafeJavaScriptSnowflakeId.ofSecond(1);
+        Assertions.assertEquals(CosId.COSID_EPOCH_SECOND, snowflakeId.getEpoch());
+    }
+}


### PR DESCRIPTION
## Summary

Bug hunt across `cosid-core`, with each candidate verified independently against the actual code (one agent-flagged "HIGH" finding — `YearMonthGroupBySupplier` — was confirmed a **false positive** via empirical check and excluded). Four real defects fixed, each with a regression test written **failing first**, then made green.

| # | Severity | Bug | Fix |
|---|----------|-----|-----|
| 1 | **High** | `SafeJavaScriptSnowflakeId.ofMillisecond(int)` passed the **seconds** epoch into a **millisecond** snowflake. `diffTimestamp = nowMs − epochSeconds` was ~1000x too large → 41-bit timestamp overflows in **~13 yrs (~2039)** instead of ~69 yrs, and the state parser returns garbage wall-clock times. | `COSID_EPOCH_SECOND` → `COSID_EPOCH` |
| 2 | **High** | `ModCycle` used raw `%` modulo, which preserves sign in Java. Any negative sharding value (e.g. a snowflake ID with the sign bit set) → negative node index → `ArrayIndexOutOfBoundsException`. | `Math.floorMod(...)` in both `sharding(T)` and `sharding(Range)` |
| 3 | **Medium** | `ExactCollection.remove()` always returned `false`, even when an element was removed — violating the `Collection.remove` contract. | return `true` when removed |
| 4 | **Low** | `DefaultClockBackwardsSynchronizer` constructor precondition message stated the **inverted** invariant (`spinThreshold must be greater than brokenThreshold`) while enforcing the opposite, making invalid-config errors misleading. | corrected message + arg order |

### Why these were uncaught
- BUG 1: `MillisecondSnowflakeIdTest.safeJavaScript()` only asserts `isSafeJavascript()` (a pure bit-count check), never the epoch.
- BUG 2: `ModCycleTest` only fed values `0–5`; negative IDs never exercised.
- BUG 3: `ExactCollectionTest.remove()` never asserted the return value.
- BUG 4: No test asserted the validation message.

## Test plan
- [x] Each new test observed **RED** with the expected failure before its fix.
- [x] `./gradlew :cosid-core:test` → **589 tests, 0 failures**.
- [x] `./gradlew :cosid-core:check -x test` → Checkstyle (main/test/jmh) + SpotBugs pass.

## Out of scope (not changed)
- `YearMonthGroupBySupplier` — agent-flagged but **verified not a bug**: `LocalDate.withMonth()` smart-adjusts the day, yielding the correct last-of-month date for all 12 months.
- Machine-subsystem local-state/lease-stamp concerns flagged by exploration — plausible but need backend integration tests to prove; left untouched rather than changed speculatively.