### PR TITLE
fix: harden starter boundaries and friendly ID parsing

### DIFF
--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
@@ -216,6 +216,12 @@ public abstract class SnowflakeIdStateParser {
         long machineId = Long.parseLong(segments.get(1));
         long sequence = Long.parseLong(segments.get(2));
         long diffTime = getDiffTime(timestamp);
+        Preconditions.checkArgument(diffTime >= 0 && diffTime <= timestampMask,
+            "timestamp:[%s] must be between 0 and maxTimestamp:[%s]!", diffTime, timestampMask);
+        Preconditions.checkArgument(machineId >= 0 && machineId <= machineMask,
+            "machineId:[%s] must be between 0 and maxMachineId:[%s]!", machineId, machineMask);
+        Preconditions.checkArgument(sequence >= 0 && sequence <= sequenceMask,
+            "sequence:[%s] must be between 0 and maxSequence:[%s]!", sequence, sequenceMask);
         /**
          * machineLeft greater than 30 will cause overflow, so machineId should be long when calculating.
          */

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
@@ -216,12 +216,9 @@ public abstract class SnowflakeIdStateParser {
         long machineId = Long.parseLong(segments.get(1));
         long sequence = Long.parseLong(segments.get(2));
         long diffTime = getDiffTime(timestamp);
-        Preconditions.checkArgument(diffTime >= 0 && diffTime <= timestampMask,
-            "timestamp:[%s] must be between 0 and maxTimestamp:[%s]!", diffTime, timestampMask);
-        Preconditions.checkArgument(machineId >= 0 && machineId <= machineMask,
-            "machineId:[%s] must be between 0 and maxMachineId:[%s]!", machineId, machineMask);
-        Preconditions.checkArgument(sequence >= 0 && sequence <= sequenceMask,
-            "sequence:[%s] must be between 0 and maxSequence:[%s]!", sequence, sequenceMask);
+        checkComponentRange("timestamp", diffTime, "maxTimestamp", timestampMask);
+        checkComponentRange("machineId", machineId, "maxMachineId", machineMask);
+        checkComponentRange("sequence", sequence, "maxSequence", sequenceMask);
         /**
          * machineLeft greater than 30 will cause overflow, so machineId should be long when calculating.
          */
@@ -235,6 +232,11 @@ public abstract class SnowflakeIdStateParser {
                 .timestamp(timestamp)
                 .friendlyId(friendlyId)
                 .build();
+    }
+
+    private void checkComponentRange(String component, long value, String maxComponent, long maxValue) {
+        Preconditions.checkArgument(value >= 0 && value <= maxValue,
+            "%s:[%s] must be between 0 and %s:[%s]!", component, value, maxComponent, maxValue);
     }
 
     /**

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SnowflakeIdStateParser.java
@@ -234,11 +234,6 @@ public abstract class SnowflakeIdStateParser {
                 .build();
     }
 
-    private void checkComponentRange(String component, long value, String maxComponent, long maxValue) {
-        Preconditions.checkArgument(value >= 0 && value <= maxValue,
-            "%s:[%s] must be between 0 and %s:[%s]!", component, value, maxComponent, maxValue);
-    }
-
     /**
      * Parses a raw snowflake ID into SnowflakeIdState.
      *
@@ -264,6 +259,11 @@ public abstract class SnowflakeIdStateParser {
                 .timestamp(timestamp)
                 .friendlyId(friendlyId)
                 .build();
+    }
+
+    private void checkComponentRange(String component, long value, String maxComponent, long maxValue) {
+        Preconditions.checkArgument(value >= 0 && value <= maxValue,
+            "%s:[%s] must be between 0 and %s:[%s]!", component, value, maxComponent, maxValue);
     }
 
     private long getMask(long bits) {

--- a/cosid-core/src/test/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverterTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverterTest.java
@@ -69,6 +69,8 @@ class SnowflakeFriendlyIdConverterTest {
 
     @ParameterizedTest
     @ValueSource(strings = {
+        "20191224235959999-5-0",
+        "99991231235959999-5-0",
         "20220320133617924-1024-0",
         "20220320133617924-5-4096"
     })

--- a/cosid-core/src/test/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverterTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/converter/SnowflakeFriendlyIdConverterTest.java
@@ -68,6 +68,15 @@ class SnowflakeFriendlyIdConverterTest {
     }
 
     @ParameterizedTest
+    @ValueSource(strings = {
+        "20220320133617924-1024-0",
+        "20220320133617924-5-4096"
+    })
+    void asLongShouldRejectComponentsOutsideSnowflakeBitRanges(String argId) {
+        Assertions.assertThrows(IllegalArgumentException.class, () -> SHANGHAI_CONVERTER.asLong(argId));
+    }
+
+    @ParameterizedTest
     @ValueSource(longs = {295913926632165376L})
     void instanceShouldRoundTripInSystemDefaultZone(long argId) {
         String idStr = SnowflakeFriendlyIdConverter.INSTANCE.asString(argId);

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/flowable/FlowableIdGeneratorAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/flowable/FlowableIdGeneratorAutoConfiguration.java
@@ -29,7 +29,11 @@ import org.springframework.context.annotation.Bean;
  */
 @AutoConfiguration
 @ConditionalOnCosIdEnabled
-@ConditionalOnClass(FlowableIdGenerator.class)
+@ConditionalOnClass({
+    FlowableIdGenerator.class,
+    SpringProcessEngineConfiguration.class,
+    EngineConfigurationConfigurer.class
+})
 public class FlowableIdGeneratorAutoConfiguration {
     
     @Bean

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdJdbcSegmentAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdJdbcSegmentAutoConfiguration.java
@@ -19,6 +19,7 @@ import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 import me.ahoo.cosid.spring.boot.starter.ConditionalOnCosIdEnabled;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -35,7 +36,8 @@ import javax.sql.DataSource;
 @ConditionalOnCosIdEnabled
 @ConditionalOnCosIdSegmentEnabled
 @EnableConfigurationProperties(SegmentIdProperties.class)
-@ConditionalOnProperty(value = SegmentIdProperties.Distributor.TYPE, matchIfMissing = true, havingValue = "jdbc")
+@ConditionalOnClass({JdbcIdSegmentInitializer.class, JdbcIdSegmentDistributorFactory.class})
+@ConditionalOnProperty(value = SegmentIdProperties.Distributor.TYPE, havingValue = "jdbc")
 public class CosIdJdbcSegmentAutoConfiguration {
 
     private final SegmentIdProperties segmentIdProperties;

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdZookeeperSegmentAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdZookeeperSegmentAutoConfiguration.java
@@ -37,7 +37,7 @@ import org.springframework.context.annotation.Bean;
 @ConditionalOnCosIdSegmentEnabled
 @EnableConfigurationProperties(SegmentIdProperties.class)
 @ConditionalOnClass(ZookeeperIdSegmentDistributor.class)
-@ConditionalOnProperty(value = SegmentIdProperties.Distributor.TYPE, matchIfMissing = true, havingValue = "zookeeper")
+@ConditionalOnProperty(value = SegmentIdProperties.Distributor.TYPE, havingValue = "zookeeper")
 public class CosIdZookeeperSegmentAutoConfiguration {
 
     @Bean

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/flowable/FlowableIdGeneratorAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/flowable/FlowableIdGeneratorAutoConfigurationTest.java
@@ -56,4 +56,14 @@ class FlowableIdGeneratorAutoConfigurationTest {
             .withClassLoader(new FilteredClassLoader(FlowableIdGenerator.class))
             .run(context -> assertThat(context).doesNotHaveBean(EngineConfigurationConfigurer.class));
     }
+
+    @Test
+    void doesNotCreateConfigurerWhenFlowableSpringIntegrationIsMissing() {
+        this.contextRunner
+            .withClassLoader(new FilteredClassLoader(
+                SpringProcessEngineConfiguration.class,
+                EngineConfigurationConfigurer.class
+            ))
+            .run(context -> assertThat(context).doesNotHaveBean(EngineConfigurationConfigurer.class));
+    }
 }

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdJdbcSegmentAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdJdbcSegmentAutoConfigurationTest.java
@@ -4,10 +4,12 @@ import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 import static org.mockito.Mockito.mock;
 
 import me.ahoo.cosid.jdbc.JdbcIdSegmentInitializer;
+import me.ahoo.cosid.jdbc.JdbcIdSegmentDistributorFactory;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import javax.sql.DataSource;
@@ -71,6 +73,31 @@ class CosIdJdbcSegmentAutoConfigurationTest {
         this.contextRunner
             .withPropertyValues(ConditionalOnCosIdSegmentEnabled.ENABLED_KEY + "=true")
             .withPropertyValues(SegmentIdProperties.Distributor.TYPE + "=redis")
+            .run(context -> assertThat(context)
+                .doesNotHaveBean(CosIdJdbcSegmentAutoConfiguration.class)
+                .doesNotHaveBean(JdbcIdSegmentInitializer.class)
+                .doesNotHaveBean(IdSegmentDistributorFactory.class));
+    }
+
+    @Test
+    void doesNotCreateJdbcSegmentBeansWhenTypeIsMissing() {
+        this.contextRunner
+            .withPropertyValues(ConditionalOnCosIdSegmentEnabled.ENABLED_KEY + "=true")
+            .run(context -> assertThat(context)
+                .doesNotHaveBean(CosIdJdbcSegmentAutoConfiguration.class)
+                .doesNotHaveBean(JdbcIdSegmentInitializer.class)
+                .doesNotHaveBean(IdSegmentDistributorFactory.class));
+    }
+
+    @Test
+    void doesNotCreateJdbcSegmentBeansWhenJdbcSegmentClassesAreMissing() {
+        this.contextRunner
+            .withPropertyValues(ConditionalOnCosIdSegmentEnabled.ENABLED_KEY + "=true")
+            .withPropertyValues(SegmentIdProperties.Distributor.TYPE + "=jdbc")
+            .withClassLoader(new FilteredClassLoader(
+                JdbcIdSegmentInitializer.class,
+                JdbcIdSegmentDistributorFactory.class
+            ))
             .run(context -> assertThat(context)
                 .doesNotHaveBean(CosIdJdbcSegmentAutoConfiguration.class)
                 .doesNotHaveBean(JdbcIdSegmentInitializer.class)

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdZookeeperSegmentAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdZookeeperSegmentAutoConfigurationTest.java
@@ -61,6 +61,15 @@ class CosIdZookeeperSegmentAutoConfigurationTest {
     }
 
     @Test
+    void doesNotCreateFactoryWhenTypeIsMissing() {
+        this.contextRunner
+            .withPropertyValues(ConditionalOnCosIdSegmentEnabled.ENABLED_KEY + "=true")
+            .run(context -> assertThat(context)
+                .doesNotHaveBean(CosIdZookeeperSegmentAutoConfiguration.class)
+                .doesNotHaveBean(IdSegmentDistributorFactory.class));
+    }
+
+    @Test
     void doesNotCreateFactoryWhenZookeeperDistributorClassIsMissing() {
         this.contextRunner
             .withClassLoader(new FilteredClassLoader(ZookeeperIdSegmentDistributor.class))


### PR DESCRIPTION
## Summary
- Harden optional Spring Boot starter auto-configuration boundaries for JDBC, Zookeeper, and Flowable integrations.
- Prevent JDBC and Zookeeper segment distributors from matching when `cosid.segment.distributor.type` is omitted, leaving the Redis default as the only missing-type segment distributor.
- Validate parsed friendly Snowflake ID components against timestamp, machine, and sequence bit ranges before rebuilding the raw ID.

## Changes
- Spring Boot starter
  - Add JDBC segment classpath guards for `JdbcIdSegmentInitializer` and `JdbcIdSegmentDistributorFactory`.
  - Remove missing-property matching from JDBC and Zookeeper segment auto-configurations.
  - Require Flowable Spring integration classes before registering the Flowable engine configurer.
  - Add `ApplicationContextRunner` coverage for missing type and missing classpath scenarios.
- Core Snowflake parsing
  - Reject friendly Snowflake IDs whose timestamp, machine ID, or sequence components exceed the configured parser masks.
  - Add regression coverage for out-of-range friendly Snowflake ID components.

## Testing
- `git diff --check`
- `./gradlew :cosid-core:check :cosid-spring-boot-starter:check --rerun-tasks --no-daemon`

## Risk & Compatibility
- Low to medium risk; this tightens invalid input and optional integration activation behavior.
- Applications relying on JDBC or Zookeeper segment auto-configuration without explicitly setting `cosid.segment.distributor.type` must now set the intended type.
- Invalid friendly Snowflake IDs with out-of-range components are now rejected instead of being folded into a raw ID.

## Review Notes
- Review the auto-configuration condition changes carefully, especially missing-property behavior for segment distributors.