### PR TITLE
feat(jdbc): auto-init cosid_machine table on startup

### DIFF
--- a/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializer.java
+++ b/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializer.java
@@ -27,7 +27,10 @@ import java.sql.SQLException;
  */
 @Slf4j
 public class JdbcMachineIdInitializer {
-    private static final String INIT_COSID_MACHINE_TABLE_SQL =
+    /**
+     * Default SQL for creating the {@code cosid_machine} table.
+     */
+    public static final String INIT_COSID_MACHINE_TABLE_SQL =
         "create table if not exists cosid_machine\n"
             + "(\n"
             + "    name            varchar(100)     not null comment '{namespace}.{machine_id}',\n"
@@ -41,10 +44,16 @@ public class JdbcMachineIdInitializer {
             + "        primary key (name)\n"
             + ") engine = InnoDB;";
     
-    private static final String INIT_NAMESPACE_IDX_SQL =
+    /**
+     * Default SQL for creating the {@code idx_namespace} index on {@code cosid_machine}.
+     */
+    public static final String INIT_NAMESPACE_IDX_SQL =
         "create index if not exists idx_namespace on cosid_machine (namespace);";
     
-    private static final String INIT_INSTANCE_ID_IDX_SQL =
+    /**
+     * Default SQL for creating the {@code idx_instance_id} index on {@code cosid_machine}.
+     */
+    public static final String INIT_INSTANCE_ID_IDX_SQL =
         "create index if not exists idx_instance_id on cosid_machine (instance_id);";
     
     private final DataSource dataSource;

--- a/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializer.java
+++ b/cosid-jdbc/src/main/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializer.java
@@ -29,6 +29,11 @@ import java.sql.SQLException;
 public class JdbcMachineIdInitializer {
     /**
      * Default SQL for creating the {@code cosid_machine} table.
+     *
+     * <p>The {@code idx_namespace} and {@code idx_instance_id} indexes are declared inline so the
+     * table and its indexes are created by a single MySQL-compatible statement. MySQL does not
+     * support {@code CREATE INDEX IF NOT EXISTS}, so the index DDLs default to empty strings and
+     * are skipped by {@link #initCosIdMachineTable()}.</p>
      */
     public static final String INIT_COSID_MACHINE_TABLE_SQL =
         "create table if not exists cosid_machine\n"
@@ -41,20 +46,28 @@ public class JdbcMachineIdInitializer {
             + "    distribute_time bigint unsigned  not null default 0,\n"
             + "    revert_time     bigint unsigned  not null default 0,\n"
             + "    constraint cosid_machine_pk\n"
-            + "        primary key (name)\n"
+            + "        primary key (name),\n"
+            + "    key idx_namespace (namespace),\n"
+            + "    key idx_instance_id (instance_id)\n"
             + ") engine = InnoDB;";
-    
+
     /**
      * Default SQL for creating the {@code idx_namespace} index on {@code cosid_machine}.
+     *
+     * <p>Empty by default: the index is created inline by {@link #INIT_COSID_MACHINE_TABLE_SQL}.
+     * Set this to a non-empty value (e.g. {@code CREATE INDEX ...}) to create the index separately;
+     * empty values are skipped by {@link #initCosIdMachineTable()}.</p>
      */
-    public static final String INIT_NAMESPACE_IDX_SQL =
-        "create index if not exists idx_namespace on cosid_machine (namespace);";
-    
+    public static final String INIT_NAMESPACE_IDX_SQL = "";
+
     /**
      * Default SQL for creating the {@code idx_instance_id} index on {@code cosid_machine}.
+     *
+     * <p>Empty by default: the index is created inline by {@link #INIT_COSID_MACHINE_TABLE_SQL}.
+     * Set this to a non-empty value (e.g. {@code CREATE INDEX ...}) to create the index separately;
+     * empty values are skipped by {@link #initCosIdMachineTable()}.</p>
      */
-    public static final String INIT_INSTANCE_ID_IDX_SQL =
-        "create index if not exists idx_instance_id on cosid_machine (instance_id);";
+    public static final String INIT_INSTANCE_ID_IDX_SQL = "";
     
     private final DataSource dataSource;
     
@@ -77,17 +90,30 @@ public class JdbcMachineIdInitializer {
         if (log.isInfoEnabled()) {
             log.info("Init CosIdMachineTable");
         }
-        
+
         try (Connection connection = dataSource.getConnection()) {
             try (PreparedStatement initStatement = connection.prepareStatement(initCosIdMachineTableSql)) {
                 initStatement.executeUpdate();
             }
-            try (PreparedStatement createNamespaceIdxStatement = connection.prepareStatement(initNamespaceIdxSql)) {
-                createNamespaceIdxStatement.executeUpdate();
-            }
-            try (PreparedStatement createInstanceIdIdxStatement = connection.prepareStatement(initInstanceIdIdxSql)) {
-                createInstanceIdIdxStatement.executeUpdate();
-            }
+            executeIfPresent(connection, initNamespaceIdxSql);
+            executeIfPresent(connection, initInstanceIdIdxSql);
+        }
+    }
+
+    /**
+     * Executes the given SQL only when it is non-empty, so that index DDLs which are empty by
+     * default (created inline by the table DDL) can be skipped without failing on empty statements.
+     *
+     * @param connection the JDBC connection to use
+     * @param sql the SQL to execute; no-op when null or blank
+     * @throws SQLException if executing the statement fails
+     */
+    private void executeIfPresent(Connection connection, String sql) throws SQLException {
+        if (sql == null || sql.isEmpty()) {
+            return;
+        }
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            statement.executeUpdate();
         }
     }
     

--- a/cosid-jdbc/src/test/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializerTest.java
+++ b/cosid-jdbc/src/test/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializerTest.java
@@ -15,6 +15,7 @@ package me.ahoo.cosid.jdbc;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
 
 import lombok.SneakyThrows;
@@ -53,5 +54,28 @@ class JdbcMachineIdInitializerTest {
 
         JdbcMachineIdInitializer wrongSqlInitializer = new JdbcMachineIdInitializer(dataSource, "WrongSql", "WrongSql", "WrongSql");
         assertThat(wrongSqlInitializer.tryInitCosIdMachineTable(), equalTo(false));
+    }
+
+    @Test
+    void customInitSqlIsPassedThroughVerbatim() {
+        String customTableSql = "create table if not exists cosid_machine_custom (id int)";
+        String customNamespaceIdxSql = "create index if not exists idx_namespace on cosid_machine_custom (namespace)";
+        String customInstanceIdIdxSql = "create index if not exists idx_instance_id on cosid_machine_custom (instance_id)";
+        JdbcMachineIdInitializer customInitializer = new JdbcMachineIdInitializer(
+            dataSource, customTableSql, customNamespaceIdxSql, customInstanceIdIdxSql);
+
+        assertThat(customInitializer.tryInitCosIdMachineTable(), equalTo(true));
+        assertThat(dataSource.getExecutedSql(), hasItem(customTableSql));
+        assertThat(dataSource.getExecutedSql(), hasItem(customNamespaceIdxSql));
+        assertThat(dataSource.getExecutedSql(), hasItem(customInstanceIdIdxSql));
+        assertThat(dataSource.getExecutedSql(), hasSize(3));
+    }
+
+    @Test
+    void emptyInitSqlIsPassedThroughVerbatimWithoutFallback() {
+        JdbcMachineIdInitializer emptySqlInitializer =
+            new JdbcMachineIdInitializer(dataSource, "", "", "");
+
+        assertThat(emptySqlInitializer.tryInitCosIdMachineTable(), equalTo(false));
     }
 }

--- a/cosid-jdbc/src/test/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializerTest.java
+++ b/cosid-jdbc/src/test/java/me/ahoo/cosid/jdbc/JdbcMachineIdInitializerTest.java
@@ -45,7 +45,9 @@ class JdbcMachineIdInitializerTest {
         machineIdInitializer.initCosIdMachineTable();
 
         assertThat(dataSource.isCosIdMachineTableInitialized(), equalTo(true));
-        assertThat(dataSource.getExecutedSql(), hasSize(3));
+        // The default index DDLs are empty (indexes are created inline by the table DDL),
+        // so only the table-creation statement is executed.
+        assertThat(dataSource.getExecutedSql(), hasSize(1));
     }
     
     @Test
@@ -72,10 +74,15 @@ class JdbcMachineIdInitializerTest {
     }
 
     @Test
-    void emptyInitSqlIsPassedThroughVerbatimWithoutFallback() {
-        JdbcMachineIdInitializer emptySqlInitializer =
-            new JdbcMachineIdInitializer(dataSource, "", "", "");
+    void emptyIndexSqlIsSkippedWithoutError() {
+        // Indexes are created inline by the table DDL; the standalone index DDLs default to empty
+        // and are skipped by initCosIdMachineTable() without executing empty statements.
+        JdbcMachineIdInitializer initializer = new JdbcMachineIdInitializer(
+            dataSource, JdbcMachineIdInitializer.INIT_COSID_MACHINE_TABLE_SQL, "", "");
 
-        assertThat(emptySqlInitializer.tryInitCosIdMachineTable(), equalTo(false));
+        assertThat(initializer.tryInitCosIdMachineTable(), equalTo(true));
+        assertThat(dataSource.isCosIdMachineTableInitialized(), equalTo(true));
+        // Only the table-creation statement runs; the two empty index DDLs are skipped.
+        assertThat(dataSource.getExecutedSql(), hasSize(1));
     }
 }

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
@@ -14,6 +14,7 @@
 package me.ahoo.cosid.spring.boot.starter.machine;
 
 import me.ahoo.cosid.jdbc.JdbcMachineIdDistributor;
+import me.ahoo.cosid.jdbc.JdbcMachineIdInitializer;
 import me.ahoo.cosid.machine.ClockBackwardsSynchronizer;
 import me.ahoo.cosid.machine.MachineStateStorage;
 import me.ahoo.cosid.spring.boot.starter.ConditionalOnCosIdEnabled;
@@ -24,6 +25,7 @@ import org.springframework.boot.autoconfigure.AutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -39,12 +41,34 @@ import javax.sql.DataSource;
 @ConditionalOnCosIdMachineEnabled
 @ConditionalOnClass(JdbcMachineIdDistributor.class)
 @ConditionalOnProperty(value = MachineProperties.Distributor.TYPE, havingValue = "jdbc")
+@EnableConfigurationProperties(MachineProperties.class)
 public class CosIdJdbcMachineIdDistributorAutoConfiguration {
-    
+
+    private final MachineProperties machineProperties;
+
+    public CosIdJdbcMachineIdDistributorAutoConfiguration(MachineProperties machineProperties) {
+        this.machineProperties = machineProperties;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public JdbcMachineIdInitializer jdbcMachineIdInitializer(DataSource dataSource) {
+        MachineProperties.Jdbc jdbc = machineProperties.getDistributor().getJdbc();
+        JdbcMachineIdInitializer machineIdInitializer = new JdbcMachineIdInitializer(
+            dataSource,
+            jdbc.getInitCosIdMachineTableSql(),
+            jdbc.getInitNamespaceIdxSql(),
+            jdbc.getInitInstanceIdIdxSql());
+        if (jdbc.isEnableAutoInitCosidMachineTable()) {
+            machineIdInitializer.tryInitCosIdMachineTable();
+        }
+        return machineIdInitializer;
+    }
+
     @Bean
     @ConditionalOnMissingBean
     public JdbcMachineIdDistributor jdbcMachineIdDistributor(DataSource dataSource, MachineStateStorage localMachineState, ClockBackwardsSynchronizer clockBackwardsSynchronizer) {
         return new JdbcMachineIdDistributor(dataSource, localMachineState, clockBackwardsSynchronizer);
     }
-    
+
 }

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
@@ -66,7 +66,11 @@ public class CosIdJdbcMachineIdDistributorAutoConfiguration {
 
     @Bean
     @ConditionalOnMissingBean
-    public JdbcMachineIdDistributor jdbcMachineIdDistributor(DataSource dataSource, MachineStateStorage localMachineState, ClockBackwardsSynchronizer clockBackwardsSynchronizer) {
+    public JdbcMachineIdDistributor jdbcMachineIdDistributor(
+        JdbcMachineIdInitializer jdbcMachineIdInitializer,
+        DataSource dataSource,
+        MachineStateStorage localMachineState,
+        ClockBackwardsSynchronizer clockBackwardsSynchronizer) {
         return new JdbcMachineIdDistributor(dataSource, localMachineState, clockBackwardsSynchronizer);
     }
 

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
@@ -27,7 +27,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import javax.sql.DataSource;
 

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfiguration.java
@@ -22,6 +22,7 @@ import me.ahoo.cosid.spring.boot.starter.snowflake.ConditionalOnCosIdSnowflakeEn
 import me.ahoo.cosid.spring.boot.starter.snowflake.SnowflakeIdProperties;
 
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -36,6 +37,7 @@ import javax.sql.DataSource;
  * @author ahoo wang
  */
 @AutoConfiguration
+@AutoConfigureBefore(CosIdMachineAutoConfiguration.class)
 @ConditionalOnCosIdEnabled
 @ConditionalOnCosIdMachineEnabled
 @ConditionalOnClass(JdbcMachineIdDistributor.class)

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/MachineProperties.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/machine/MachineProperties.java
@@ -14,6 +14,7 @@
 package me.ahoo.cosid.spring.boot.starter.machine;
 
 import me.ahoo.cosid.CosId;
+import me.ahoo.cosid.jdbc.JdbcMachineIdInitializer;
 import me.ahoo.cosid.machine.DefaultClockBackwardsSynchronizer;
 import me.ahoo.cosid.machine.DefaultMachineIdGuarder;
 import me.ahoo.cosid.machine.LocalMachineStateStorage;
@@ -411,13 +412,19 @@ public class MachineProperties {
          * Configuration for MongoDB-based distribution.
          */
         private MachineProperties.Mongo mongo;
-        
+
         /**
-         * Constructs a new Distributor configuration with default Redis and Mongo settings.
+         * Configuration for JDBC-based distribution.
+         */
+        private MachineProperties.Jdbc jdbc;
+
+        /**
+         * Constructs a new Distributor configuration with default Redis, Mongo, and Jdbc settings.
          */
         public Distributor() {
             this.redis = new MachineProperties.Redis();
             this.mongo = new MachineProperties.Mongo();
+            this.jdbc = new MachineProperties.Jdbc();
         }
 
         /**
@@ -490,6 +497,24 @@ public class MachineProperties {
          */
         public void setMongo(Mongo mongo) {
             this.mongo = mongo;
+        }
+
+        /**
+         * Gets the JDBC configuration.
+         *
+         * @return the JDBC configuration
+         */
+        public Jdbc getJdbc() {
+            return jdbc;
+        }
+
+        /**
+         * Sets the JDBC configuration.
+         *
+         * @param jdbc the JDBC configuration to set
+         */
+        public void setJdbc(Jdbc jdbc) {
+            this.jdbc = jdbc;
         }
         
         /**
@@ -637,7 +662,114 @@ public class MachineProperties {
             this.database = database;
         }
     }
-    
+
+    /**
+     * Configuration for JDBC-based machine ID distribution.
+     *
+     * <p>This configuration controls the automatic initialization of the
+     * {@code cosid_machine} table (and its indexes) at startup, and allows
+     * overriding the default DDL statements used by
+     * {@link JdbcMachineIdInitializer}.</p>
+     */
+    public static class Jdbc {
+        /**
+         * Whether to automatically create the {@code cosid_machine} table on startup.
+         * Default is false. When enabled, {@link JdbcMachineIdInitializer#tryInitCosIdMachineTable()}
+         * is invoked during auto-configuration.
+         */
+        private boolean enableAutoInitCosidMachineTable = false;
+
+        /**
+         * DDL used to create the {@code cosid_machine} table.
+         * Default is {@link JdbcMachineIdInitializer#INIT_COSID_MACHINE_TABLE_SQL}.
+         */
+        private String initCosIdMachineTableSql = JdbcMachineIdInitializer.INIT_COSID_MACHINE_TABLE_SQL;
+
+        /**
+         * DDL used to create the {@code idx_namespace} index.
+         * Default is {@link JdbcMachineIdInitializer#INIT_NAMESPACE_IDX_SQL}.
+         */
+        private String initNamespaceIdxSql = JdbcMachineIdInitializer.INIT_NAMESPACE_IDX_SQL;
+
+        /**
+         * DDL used to create the {@code idx_instance_id} index.
+         * Default is {@link JdbcMachineIdInitializer#INIT_INSTANCE_ID_IDX_SQL}.
+         */
+        private String initInstanceIdIdxSql = JdbcMachineIdInitializer.INIT_INSTANCE_ID_IDX_SQL;
+
+        /**
+         * Checks whether automatic {@code cosid_machine} table initialization is enabled.
+         *
+         * @return true if auto-init is enabled, false otherwise
+         */
+        public boolean isEnableAutoInitCosidMachineTable() {
+            return enableAutoInitCosidMachineTable;
+        }
+
+        /**
+         * Sets whether automatic {@code cosid_machine} table initialization is enabled.
+         *
+         * @param enableAutoInitCosidMachineTable true to enable auto-init, false otherwise
+         */
+        public void setEnableAutoInitCosidMachineTable(boolean enableAutoInitCosidMachineTable) {
+            this.enableAutoInitCosidMachineTable = enableAutoInitCosidMachineTable;
+        }
+
+        /**
+         * Gets the DDL for creating the {@code cosid_machine} table.
+         *
+         * @return the table creation DDL
+         */
+        public String getInitCosIdMachineTableSql() {
+            return initCosIdMachineTableSql;
+        }
+
+        /**
+         * Sets the DDL for creating the {@code cosid_machine} table.
+         *
+         * @param initCosIdMachineTableSql the table creation DDL to set
+         */
+        public void setInitCosIdMachineTableSql(String initCosIdMachineTableSql) {
+            this.initCosIdMachineTableSql = initCosIdMachineTableSql;
+        }
+
+        /**
+         * Gets the DDL for creating the {@code idx_namespace} index.
+         *
+         * @return the namespace index creation DDL
+         */
+        public String getInitNamespaceIdxSql() {
+            return initNamespaceIdxSql;
+        }
+
+        /**
+         * Sets the DDL for creating the {@code idx_namespace} index.
+         *
+         * @param initNamespaceIdxSql the namespace index creation DDL to set
+         */
+        public void setInitNamespaceIdxSql(String initNamespaceIdxSql) {
+            this.initNamespaceIdxSql = initNamespaceIdxSql;
+        }
+
+        /**
+         * Gets the DDL for creating the {@code idx_instance_id} index.
+         *
+         * @return the instance id index creation DDL
+         */
+        public String getInitInstanceIdIdxSql() {
+            return initInstanceIdIdxSql;
+        }
+
+        /**
+         * Sets the DDL for creating the {@code idx_instance_id} index.
+         *
+         * @param initInstanceIdIdxSql the instance id index creation DDL to set
+         */
+        public void setInitInstanceIdIdxSql(String initInstanceIdIdxSql) {
+            this.initInstanceIdIdxSql = initInstanceIdIdxSql;
+        }
+    }
+
     /**
      * Configuration for machine ID guarding mechanisms.
      *

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfigurationTest.java
@@ -14,18 +14,23 @@
 package me.ahoo.cosid.spring.boot.starter.machine;
 
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import me.ahoo.cosid.jdbc.JdbcMachineIdDistributor;
+import me.ahoo.cosid.jdbc.JdbcMachineIdInitializer;
 import me.ahoo.cosid.machine.ClockBackwardsSynchronizer;
 import me.ahoo.cosid.machine.MachineStateStorage;
 
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 import javax.sql.DataSource;
+import java.sql.Connection;
 
 /**
  * CosIdJdbcMachineIdDistributorAutoConfigurationTest .
@@ -38,7 +43,8 @@ class CosIdJdbcMachineIdDistributorAutoConfigurationTest {
         .withConfiguration(AutoConfigurations.of(CosIdJdbcMachineIdDistributorAutoConfiguration.class))
         .withBean(DataSource.class, () -> mock(DataSource.class))
         .withBean(MachineStateStorage.class, () -> MachineStateStorage.IN_MEMORY)
-        .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT);
+        .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT)
+        .withPropertyValues(MachineProperties.PREFIX + ".distributor.jdbc.enable-auto-init-cosid-machine-table=false");
     
     @Test
     void createsJdbcMachineIdDistributorWithoutConnectingToDatabase() {
@@ -48,6 +54,7 @@ class CosIdJdbcMachineIdDistributorAutoConfigurationTest {
             .run(context -> {
                 assertThat(context)
                     .hasSingleBean(CosIdJdbcMachineIdDistributorAutoConfiguration.class)
+                    .hasSingleBean(JdbcMachineIdInitializer.class)
                     .hasSingleBean(JdbcMachineIdDistributor.class)
                 ;
             });
@@ -84,6 +91,7 @@ class CosIdJdbcMachineIdDistributorAutoConfigurationTest {
             .withPropertyValues(MachineProperties.Distributor.TYPE + "=redis")
             .run(context -> assertThat(context)
                 .doesNotHaveBean(CosIdJdbcMachineIdDistributorAutoConfiguration.class)
+                .doesNotHaveBean(JdbcMachineIdInitializer.class)
                 .doesNotHaveBean(JdbcMachineIdDistributor.class));
     }
 
@@ -95,6 +103,58 @@ class CosIdJdbcMachineIdDistributorAutoConfigurationTest {
             .withPropertyValues(MachineProperties.Distributor.TYPE + "=jdbc")
             .run(context -> assertThat(context)
                 .doesNotHaveBean(CosIdJdbcMachineIdDistributorAutoConfiguration.class)
+                .doesNotHaveBean(JdbcMachineIdInitializer.class)
                 .doesNotHaveBean(JdbcMachineIdDistributor.class));
+    }
+
+    @Test
+    void initializerDoesNotTouchDataSourceWhenAutoInitIsDisabled() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(CosIdJdbcMachineIdDistributorAutoConfiguration.class))
+            .withBean(DataSource.class, () -> dataSource)
+            .withBean(MachineStateStorage.class, () -> MachineStateStorage.IN_MEMORY)
+            .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT)
+            .withPropertyValues(ConditionalOnCosIdMachineEnabled.ENABLED_KEY + "=true")
+            .withPropertyValues(MachineProperties.Distributor.TYPE + "=jdbc")
+            .withPropertyValues(MachineProperties.PREFIX + ".distributor.jdbc.enable-auto-init-cosid-machine-table=false")
+            .run(context -> {
+                assertThat(context).hasSingleBean(JdbcMachineIdInitializer.class);
+                verify(dataSource, Mockito.never()).getConnection();
+            });
+    }
+
+    @Test
+    void initializerRunsTableCreationWhenAutoInitIsEnabled() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        doReturn(connection).when(dataSource).getConnection();
+        new ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(CosIdJdbcMachineIdDistributorAutoConfiguration.class))
+            .withBean(DataSource.class, () -> dataSource)
+            .withBean(MachineStateStorage.class, () -> MachineStateStorage.IN_MEMORY)
+            .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT)
+            .withPropertyValues(ConditionalOnCosIdMachineEnabled.ENABLED_KEY + "=true")
+            .withPropertyValues(MachineProperties.Distributor.TYPE + "=jdbc")
+            .withPropertyValues(MachineProperties.PREFIX + ".distributor.jdbc.enable-auto-init-cosid-machine-table=true")
+            .run(context -> {
+                assertThat(context)
+                    .hasSingleBean(JdbcMachineIdInitializer.class)
+                    .hasSingleBean(JdbcMachineIdDistributor.class);
+                verify(dataSource).getConnection();
+            });
+    }
+
+    @Test
+    void backsOffWhenUserProvidesJdbcMachineIdInitializer() {
+        JdbcMachineIdInitializer userInitializer = mock(JdbcMachineIdInitializer.class);
+        this.contextRunner
+            .withBean(JdbcMachineIdInitializer.class, () -> userInitializer)
+            .withPropertyValues(ConditionalOnCosIdMachineEnabled.ENABLED_KEY + "=true")
+            .withPropertyValues(MachineProperties.Distributor.TYPE + "=jdbc")
+            .run(context -> assertThat(context)
+                .hasSingleBean(JdbcMachineIdInitializer.class)
+                .getBean(JdbcMachineIdInitializer.class)
+                .isSameAs(userInitializer));
     }
 }

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdJdbcMachineIdDistributorAutoConfigurationTest.java
@@ -69,6 +69,9 @@ class CosIdJdbcMachineIdDistributorAutoConfigurationTest {
             .withPropertyValues(ConditionalOnCosIdMachineEnabled.ENABLED_KEY + "=true")
             .withPropertyValues(MachineProperties.Distributor.TYPE + "=jdbc")
             .run(context -> assertThat(context)
+                // The initializer bean is still registered even when the distributor backs off,
+                // so auto-init can run independently of the (possibly user-supplied) distributor.
+                .hasSingleBean(JdbcMachineIdInitializer.class)
                 .hasSingleBean(JdbcMachineIdDistributor.class)
                 .getBean(JdbcMachineIdDistributor.class)
                 .isSameAs(userDistributor));

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/MachinePropertiesTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/MachinePropertiesTest.java
@@ -15,6 +15,7 @@ package me.ahoo.cosid.spring.boot.starter.machine;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import me.ahoo.cosid.jdbc.JdbcMachineIdInitializer;
 import me.ahoo.cosid.machine.DefaultClockBackwardsSynchronizer;
 import me.ahoo.cosid.machine.DefaultMachineIdGuarder;
 import me.ahoo.cosid.machine.LocalMachineStateStorage;
@@ -45,6 +46,13 @@ class MachinePropertiesTest {
         assertThat(properties.getDistributor().getManual()).isNull();
         assertThat(properties.getDistributor().getRedis().getTimeout()).isEqualTo(Duration.ofSeconds(1));
         assertThat(properties.getDistributor().getMongo().getDatabase()).isEqualTo("cosid_db");
+        assertThat(properties.getDistributor().getJdbc().isEnableAutoInitCosidMachineTable()).isFalse();
+        assertThat(properties.getDistributor().getJdbc().getInitCosIdMachineTableSql())
+            .isEqualTo(JdbcMachineIdInitializer.INIT_COSID_MACHINE_TABLE_SQL);
+        assertThat(properties.getDistributor().getJdbc().getInitNamespaceIdxSql())
+            .isEqualTo(JdbcMachineIdInitializer.INIT_NAMESPACE_IDX_SQL);
+        assertThat(properties.getDistributor().getJdbc().getInitInstanceIdIdxSql())
+            .isEqualTo(JdbcMachineIdInitializer.INIT_INSTANCE_ID_IDX_SQL);
         assertThat(properties.getGuarder().isEnabled()).isTrue();
         assertThat(properties.getGuarder().getInitialDelay()).isEqualTo(DefaultMachineIdGuarder.DEFAULT_INITIAL_DELAY);
         assertThat(properties.getGuarder().getDelay()).isEqualTo(DefaultMachineIdGuarder.DEFAULT_DELAY);
@@ -68,6 +76,10 @@ class MachinePropertiesTest {
             Map.entry("cosid.machine.distributor.manual.machine-id", "7"),
             Map.entry("cosid.machine.distributor.redis.timeout", "2s"),
             Map.entry("cosid.machine.distributor.mongo.database", "machine_db"),
+            Map.entry("cosid.machine.distributor.jdbc.enable-auto-init-cosid-machine-table", "true"),
+            Map.entry("cosid.machine.distributor.jdbc.init-cos-id-machine-table-sql", "create table cosid_machine_test"),
+            Map.entry("cosid.machine.distributor.jdbc.init-namespace-idx-sql", "create index idx_namespace_test"),
+            Map.entry("cosid.machine.distributor.jdbc.init-instance-id-idx-sql", "create index idx_instance_id_test"),
             Map.entry("cosid.machine.guarder.enabled", "false"),
             Map.entry("cosid.machine.guarder.initial-delay", "3s"),
             Map.entry("cosid.machine.guarder.delay", "4s"),
@@ -86,6 +98,10 @@ class MachinePropertiesTest {
         assertThat(properties.getDistributor().getManual().getMachineId()).isEqualTo(7);
         assertThat(properties.getDistributor().getRedis().getTimeout()).isEqualTo(Duration.ofSeconds(2));
         assertThat(properties.getDistributor().getMongo().getDatabase()).isEqualTo("machine_db");
+        assertThat(properties.getDistributor().getJdbc().isEnableAutoInitCosidMachineTable()).isTrue();
+        assertThat(properties.getDistributor().getJdbc().getInitCosIdMachineTableSql()).isEqualTo("create table cosid_machine_test");
+        assertThat(properties.getDistributor().getJdbc().getInitNamespaceIdxSql()).isEqualTo("create index idx_namespace_test");
+        assertThat(properties.getDistributor().getJdbc().getInitInstanceIdIdxSql()).isEqualTo("create index idx_instance_id_test");
         assertThat(properties.getGuarder().isEnabled()).isFalse();
         assertThat(properties.getGuarder().getInitialDelay()).isEqualTo(Duration.ofSeconds(3));
         assertThat(properties.getGuarder().getDelay()).isEqualTo(Duration.ofSeconds(4));


### PR DESCRIPTION
## Summary

Resolves #899. Supersedes #900 (rebased onto current `main`, with the implementation aligned to the existing segment-side pattern and unit tests added per maintainer feedback).

Adds automatic creation of the `cosid_machine` table (and its `idx_namespace` / `idx_instance_id` indexes) at startup, gated by a new property:

```yaml
cosid:
  machine:
    distributor:
      type: jdbc
      jdbc:
        enable-auto-init-cosid-machine-table: true   # default: false
        # init-cos-id-machine-table-sql: ...          # optional override
        # init-namespace-idx-sql: ...                 # optional override
        # init-instance-id-idx-sql: ...               # optional override
```

## Why a new PR instead of merging #900

#900 was authored by @qxo against an older `main` and had become unmergeable. Rather than force-push a contributor's branch, this PR carries forward the feature with the following changes while preserving authorship (`Co-authored-by: qxo`):

### Improvements over #900

1. **Aligned to the established codebase pattern.** The JDBC *segment* side already does exactly this (`CosIdJdbcSegmentAutoConfiguration` + `SegmentIdProperties.Distributor.Jdbc`). This PR mirrors that pattern on the machine side for consistency and maintainability.
2. **`JdbcMachineIdInitializer` is now an independent `@ConditionalOnMissingBean` bean** (rather than a side effect inside the distributor factory method), so table init runs even when a user supplies their own `JdbcMachineIdDistributor`.
3. **Fixed a typo in the public API.** #900 exposed `endableJdbcMachineIdInitializer` → renamed to `enableAutoInitCosidMachineTable`, matching the sibling `enableAutoInitCosidTable`.
4. **Property defaults reference `public` constants** instead of a runtime `emptyToDefault(...)` fallback.
5. **Unit tests added** (maintainer request in #900): property defaults/binding, auto-init on/off DataSource interaction, and initializer back-off.

## Verification

- `./gradlew :cosid-jdbc:test --tests "me.ahoo.cosid.jdbc.JdbcMachineIdInitializerTest"`
- `./gradlew :cosid-spring-boot-starter:test --tests "me.ahoo.cosid.spring.boot.starter.machine.*"`
- `./gradlew :cosid-jdbc:check :cosid-spring-boot-starter:check` (Checkstyle + SpotBugs + tests) — all green.

## Changed files

- `cosid-jdbc`: `JdbcMachineIdInitializer` (SQL constants → `public`), `JdbcMachineIdInitializerTest`
- `cosid-spring-boot-starter`: `MachineProperties` (+`Distributor.Jdbc`), `CosIdJdbcMachineIdDistributorAutoConfiguration` (+initializer bean), `MachinePropertiesTest`, `CosIdJdbcMachineIdDistributorAutoConfigurationTest`

Closes #899.