### PR TITLE
fix(deps): update coapi to v2.1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "4.1.0"
 spring-cloud = "2025.1.2"
 jspecify = "1.0.0"
-coapi = "2.0.1"
+coapi = "2.1.0"
 testcontainers = "2.0.5"
 guava = "33.6.0-jre"
 mybatis = "3.5.19"


### PR DESCRIPTION
## Summary

Bumps `me.ahoo.coapi:coapi-bom` from `2.0.1` to `2.1.0`.

## Verification

Compiled all modules that depend on coapi — all green (no breaking API changes in 2.1.0):

- `:cosid-proxy-api:compileJava`
- `:cosid-spring-boot-starter:compileJava`
- `:cosid-proxy:compileJava`
- `:cosid-example-proxy:compileJava`