### PR TITLE
chore(release): bump version to 3.2.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 group=me.ahoo.cosid
-version=3.1.0
+version=3.2.0
 description=Universal, flexible, high-performance distributed ID generator.
 website=https://github.com/Ahoo-Wang/CosId
 issues=https://github.com/Ahoo-Wang/CosId/issues


### PR DESCRIPTION
Bumps the project version from `3.1.0` to `3.2.0` in `gradle.properties`.

Follows the established release-bump convention (cf. `1c83e859 chore(release): bump version to 3.1.0`); the version is centrally managed in `gradle.properties` only.