### PR TITLE
fix: correctness fixes from full-module code review (sharding overflow, proxy-server self-heal, snowflake epoch, actuate NPE)

### DIFF
--- a/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/sharding/ModCycle.java
@@ -86,6 +86,10 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
             return effectiveNodes;
         }
 
+        if (shardingValue.isEmpty()) {
+            return ExactCollection.empty();
+        }
+
         long lower = 0;
         if (shardingValue.hasLowerBound()) {
             long lowerEndpoint = shardingValue.lowerEndpoint().longValue();
@@ -96,15 +100,20 @@ public class ModCycle<T extends Number & Comparable<T>> implements Sharding<T> {
 
         long upper = BoundType.OPEN.equals(shardingValue.upperBoundType()) ? (upperEndpoint - 1) : upperEndpoint;
 
-        final int nodeSize = (int) (upper - lower + 1);
-
-        if (nodeSize == 0) {
+        if (upper < lower) {
             return ExactCollection.empty();
         }
 
-        if (nodeSize >= divisor) {
+        if (lower < 0 && upper >= 0 && (upper - lower) < 0) {
+            // the mathematical span (>= 2^63) overflowed the subtraction and covers every node
             return effectiveNodes;
         }
+
+        if (upper - lower >= divisor - 1) {
+            return effectiveNodes;
+        }
+
+        final int nodeSize = (int) (upper - lower + 1);
 
         ExactCollection<String> nodes = new ExactCollection<>(nodeSize);
         int idx = 0;

--- a/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeId.java
+++ b/cosid-core/src/main/java/me/ahoo/cosid/snowflake/SafeJavaScriptSnowflakeId.java
@@ -80,7 +80,7 @@ public final class SafeJavaScriptSnowflakeId {
         final int machineBit = MillisecondSnowflakeId.DEFAULT_MACHINE_BIT - 7;
         final int sequenceBit = MillisecondSnowflakeId.DEFAULT_SEQUENCE_BIT - 3;
         checkTotalBit(timestampBit, machineBit, sequenceBit);
-        return ofMillisecond(CosId.COSID_EPOCH_SECOND, timestampBit, machineBit, sequenceBit, machineId, SnowflakeId.defaultSequenceResetThreshold(sequenceBit));
+        return ofMillisecond(CosId.COSID_EPOCH, timestampBit, machineBit, sequenceBit, machineId, SnowflakeId.defaultSequenceResetThreshold(sequenceBit));
     }
 
     /**

--- a/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
@@ -164,6 +164,11 @@ class ModCycleTest {
             arguments(Range.closed(Long.MIN_VALUE, Long.MAX_VALUE), ALL_NODES),
             arguments(Range.closedOpen(Long.MIN_VALUE, Long.MAX_VALUE), ALL_NODES),
             /**
+             * Sign-overflow guard branch combinations: cross-zero without wraparound, and negative-only spans
+             */
+            arguments(Range.closedOpen(-3L, 1L), ALL_NODES),
+            arguments(Range.closed(-8L, -1L), ALL_NODES),
+            /**
              * Empty ranges at equal endpoints
              */
             arguments(Range.closedOpen(3L, 3L), ExactCollection.empty()),

--- a/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/sharding/ModCycleTest.java
@@ -152,7 +152,22 @@ class ModCycleTest {
             arguments(Range.atMost(2L), new ExactCollection<>("t_mod_0", "t_mod_1", "t_mod_2")),
             arguments(Range.atMost(3L), ALL_NODES),
             arguments(Range.atMost(4L), ALL_NODES),
-            arguments(Range.atMost(5L), ALL_NODES)
+            arguments(Range.atMost(5L), ALL_NODES),
+            /**
+             * Ranges whose span overflows int node-size arithmetic
+             */
+            arguments(Range.closed(0L, Long.MAX_VALUE), ALL_NODES),
+            arguments(Range.atMost(Long.MAX_VALUE), ALL_NODES),
+            arguments(Range.closedOpen(0L, Long.MAX_VALUE), ALL_NODES),
+            arguments(Range.lessThan(Long.MAX_VALUE), ALL_NODES),
+            arguments(Range.closedOpen(0L, 1L << 32), ALL_NODES),
+            arguments(Range.closed(Long.MIN_VALUE, Long.MAX_VALUE), ALL_NODES),
+            arguments(Range.closedOpen(Long.MIN_VALUE, Long.MAX_VALUE), ALL_NODES),
+            /**
+             * Empty ranges at equal endpoints
+             */
+            arguments(Range.closedOpen(3L, 3L), ExactCollection.empty()),
+            arguments(Range.openClosed(3L, 3L), ExactCollection.empty())
         );
     }
 

--- a/cosid-core/src/test/java/me/ahoo/cosid/snowflake/MillisecondSnowflakeIdTest.java
+++ b/cosid-core/src/test/java/me/ahoo/cosid/snowflake/MillisecondSnowflakeIdTest.java
@@ -95,6 +95,15 @@ class MillisecondSnowflakeIdTest {
     }
 
     @Test
+    public void safeJavaScriptFactoriesShouldUseEpochInMatchingTimeUnit() {
+        MillisecondSnowflakeId millisecond = SafeJavaScriptSnowflakeId.ofMillisecond(1);
+        Assertions.assertEquals(CosId.COSID_EPOCH, millisecond.getEpoch());
+
+        SecondSnowflakeId second = SafeJavaScriptSnowflakeId.ofSecond(1);
+        Assertions.assertEquals(CosId.COSID_EPOCH_SECOND, second.getEpoch());
+    }
+
+    @Test
     public void customizeBits() {
         SnowflakeId snowflakeId = new MillisecondSnowflakeId(CosId.COSID_EPOCH, 41, 5, 10, 1);
         long id = snowflakeId.generate();

--- a/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/actuate/CosIdEndpoint.java
+++ b/cosid-spring-boot-starter/src/main/java/me/ahoo/cosid/spring/boot/starter/actuate/CosIdEndpoint.java
@@ -52,7 +52,8 @@ public class CosIdEndpoint {
     
     @DeleteOperation
     public IdGeneratorStat remove(@Selector String name) {
-        var idGenerator = idGeneratorProvider.remove(name);
+        var idGenerator = idGeneratorProvider.getRequired(name);
+        idGeneratorProvider.remove(name);
         return idGenerator.stat();
     }
     

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/actuate/CosIdEndpointTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/actuate/CosIdEndpointTest.java
@@ -60,6 +60,15 @@ class CosIdEndpointTest {
         assertThat(provider.getShare()).isSameAs(MockIdGenerator.INSTANCE);
     }
 
+    @Test
+    void removePropagatesMissingGeneratorFailure() {
+        CosIdEndpoint endpoint = new CosIdEndpoint(new DefaultIdGeneratorProvider());
+
+        assertThatThrownBy(() -> endpoint.remove("missing"))
+            .isInstanceOf(RuntimeException.class)
+            .hasMessageContaining("missing");
+    }
+
     private static DefaultIdGeneratorProvider newProviderWithShareAndOrders() {
         DefaultIdGeneratorProvider provider = new DefaultIdGeneratorProvider();
         provider.setShare(MockIdGenerator.INSTANCE);

--- a/proxy/cosid-proxy-server/src/main/java/me/ahoo/cosid/proxy/server/controller/SegmentController.java
+++ b/proxy/cosid-proxy-server/src/main/java/me/ahoo/cosid/proxy/server/controller/SegmentController.java
@@ -18,7 +18,6 @@ import me.ahoo.cosid.segment.IdSegmentDistributor;
 import me.ahoo.cosid.segment.IdSegmentDistributorDefinition;
 import me.ahoo.cosid.segment.IdSegmentDistributorFactory;
 
-import com.google.common.base.Preconditions;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,13 +49,22 @@ public class SegmentController implements SegmentApi {
         distributors.computeIfAbsent(namespacedName,
             key -> distributorFactory.create(new IdSegmentDistributorDefinition(namespace, name, offset, step)));
     }
-    
+
+    /**
+     * Get next max id.
+     *
+     * <p>Distributors are cached in memory only. On a cache miss (e.g. after a server restart,
+     * when running clients no longer re-send {@code createDistributor}) the distributor is
+     * rebuilt lazily with {@link IdSegmentDistributor#DEFAULT_OFFSET}: the backing store
+     * applies an offset only on first-ever initialization, so already-allocated segment
+     * state survives the rebuild.
+     */
     @Override
     @Operation(summary = "Get next max id.")
     public long nextMaxId(@PathVariable String namespace, @PathVariable String name, long step) {
         String namespacedName = IdSegmentDistributor.getNamespacedName(namespace, name);
-        IdSegmentDistributor distributor = distributors.get(namespacedName);
-        Preconditions.checkNotNull(distributor);
+        IdSegmentDistributor distributor = distributors.computeIfAbsent(namespacedName,
+            key -> distributorFactory.create(new IdSegmentDistributorDefinition(namespace, name, IdSegmentDistributor.DEFAULT_OFFSET, step)));
         return distributor.nextMaxId(step);
     }
 }

--- a/proxy/cosid-proxy-server/src/test/java/me/ahoo/cosid/proxy/server/ProxyServerTest.java
+++ b/proxy/cosid-proxy-server/src/test/java/me/ahoo/cosid/proxy/server/ProxyServerTest.java
@@ -33,6 +33,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.web.reactive.server.WebTestClient;
 
 import java.time.Duration;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 
 /**
@@ -69,6 +71,65 @@ class ProxyServerTest {
             .expectStatus().isOk()
             .expectBody(Long.class)
             .isEqualTo(105L);
+    }
+
+    @Test
+    void nextMaxIdShouldSelfHealAfterServerRestart() {
+        StatefulIdSegmentDistributorFactory backendFactory = new StatefulIdSegmentDistributorFactory();
+        WebTestClient serverBeforeRestart = WebTestClient
+            .bindToController(new SegmentController(backendFactory))
+            .controllerAdvice(new GlobalRestExceptionHandler())
+            .build();
+
+        serverBeforeRestart
+            .post()
+            .uri("/segments/distributor/test_namespace/order?offset=100&step=20")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody().isEmpty();
+
+        serverBeforeRestart
+            .patch()
+            .uri("/segments/test_namespace/order?step=20")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(Long.class)
+            .isEqualTo(120L);
+
+        WebTestClient serverAfterRestart = WebTestClient
+            .bindToController(new SegmentController(backendFactory))
+            .controllerAdvice(new GlobalRestExceptionHandler())
+            .build();
+
+        serverAfterRestart
+            .patch()
+            .uri("/segments/test_namespace/order?step=5")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(Long.class)
+            .isEqualTo(125L);
+    }
+
+    /**
+     * Contract lock for the deliberate lazy-initialization semantics of nextMaxId:
+     * a never-created name starts from DEFAULT_OFFSET instead of failing. Not a bug
+     * reproduction — this behavior is GREEN by design since the self-heal fix.
+     */
+    @Test
+    void nextMaxIdShouldLazilyInitializeNeverCreatedSegment() {
+        StatefulIdSegmentDistributorFactory backendFactory = new StatefulIdSegmentDistributorFactory();
+        WebTestClient server = WebTestClient
+            .bindToController(new SegmentController(backendFactory))
+            .controllerAdvice(new GlobalRestExceptionHandler())
+            .build();
+
+        server
+            .patch()
+            .uri("/segments/test_namespace/fresh?step=10")
+            .exchange()
+            .expectStatus().isOk()
+            .expectBody(Long.class)
+            .isEqualTo(10L);
     }
 
     @Test
@@ -153,6 +214,52 @@ class ProxyServerTest {
         public long nextMaxId(long step) {
             maxId += step;
             return maxId;
+        }
+    }
+
+    private static class StatefulIdSegmentDistributorFactory implements IdSegmentDistributorFactory {
+        private final ConcurrentHashMap<String, AtomicLong> maxIds = new ConcurrentHashMap<>();
+
+        @Override
+        public IdSegmentDistributor create(IdSegmentDistributorDefinition definition) {
+            AtomicLong maxId = maxIds.computeIfAbsent(definition.getNamespacedName(),
+                key -> new AtomicLong(definition.getOffset()));
+            return new StatefulIdSegmentDistributor(definition, maxId);
+        }
+    }
+
+    private static class StatefulIdSegmentDistributor implements IdSegmentDistributor {
+        private final IdSegmentDistributorDefinition definition;
+        private final AtomicLong maxId;
+
+        StatefulIdSegmentDistributor(IdSegmentDistributorDefinition definition, AtomicLong maxId) {
+            this.definition = definition;
+            this.maxId = maxId;
+        }
+
+        @Override
+        public String getNamespace() {
+            return definition.getNamespace();
+        }
+
+        @Override
+        public String getName() {
+            return definition.getName();
+        }
+
+        @Override
+        public long getStep() {
+            return definition.getStep();
+        }
+
+        @Override
+        public GroupedKey group() {
+            return GroupedKey.NEVER;
+        }
+
+        @Override
+        public long nextMaxId(long step) {
+            return maxId.addAndGet(step);
         }
     }
 


### PR DESCRIPTION
## Summary

Four correctness fixes found by a full-module code review, each developed test-first (failing test observed RED before every implementation change) and hardened by a follow-up code review pass.

## Changes

- **fix(sharding): `ModCycle` range-sharding node-size overflow** — `sharding(Range)` computed `(int)(upper - lower + 1)`: spans ≥ 2^31 truncated after long→int cast, so `Range.closed(0L, Long.MAX_VALUE)` silently returned an **empty node collection** (should be all nodes) and `closedOpen(0L, Long.MAX_VALUE)` threw `NegativeArraySizeException`. Empty ranges are now detected via `Range.isEmpty()`, span comparisons happen in long arithmetic before any int cast, and the cross-zero subtraction wraparound (mathematical span ≥ 2^63) is guarded.
- **fix(proxy-server): segment distributor cache self-heals after restart** — the in-memory cache was only populated by the client's one-time `createDistributor` call, so a proxy-server restart left every running client failing `nextMaxId` with HTTP 500 **forever**. `nextMaxId` now rebuilds the distributor lazily (`computeIfAbsent`) with `DEFAULT_OFFSET`; backends apply an offset only on first-ever initialization (`setIfAbsent` / insert-if-absent), so existing segment state survives the rebuild.
- **fix(snowflake): `SafeJavaScriptSnowflakeId.ofMillisecond` epoch unit mismatch** — the factory passed `COSID_EPOCH_SECOND` (seconds) as the epoch of a millisecond-based snowflake, collapsing the timestamp lifetime to ~2039 (designed: 2080s) and inflating IDs by ~49 years of timestamp delta. Uniqueness was unaffected; the only in-repo consumer is a JMH benchmark.
- **fix(starter): `CosIdEndpoint.remove` NPE** — `DELETE /actuator/cosid/{unknown-name}` dereferenced null and surfaced as a 500-causing NPE while `getStat` on the same endpoint failed cleanly. Now validates via `getRequired(name)` first.

## Behavior changes worth noting

- proxy-server: `nextMaxId` for a never-created name now succeeds starting from offset 0 instead of returning 500 (documented on the endpoint; covered by a contract test).
- `SafeJavaScriptSnowflakeId.ofMillisecond(machineId)` now generates IDs of a different magnitude — breaking only for callers persisting parsed states across the upgrade (none in-repo).

## Testing

- [x] Every fix has a test that was observed failing for the expected reason before the change (TDD RED→GREEN)
- [x] `./gradlew cosid-core:check` (tests + Checkstyle + SpotBugs + JaCoCo)
- [x] `./gradlew cosid-proxy-server:check`
- [x] `cosid-spring-boot-starter`: `checkstyleMain` / `spotbugsMain` / `checkstyleTest` + actuate package tests (full module test run requires a live MySQL, not available locally)
- [x] Follow-up code review pass (independent reviewer agent): 0 Critical findings; the two Important findings (cross-zero overflow, missing lazy-create contract test/docs) are addressed in this PR
