### PR TITLE
fix(ci): disable build attestations for Aliyun ACR push

### DIFF
--- a/.github/workflows/docker-deploy.yml
+++ b/.github/workflows/docker-deploy.yml
@@ -109,3 +109,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # Aliyun ACR rejects OCI attestation manifests (unknown manifest class for
+          # application/vnd.oci.empty.v1+json), and attestations are on by default.
+          provenance: false
+          sbom: false


### PR DESCRIPTION
## Summary

Every recent **Docker Image Deploy** run has failed across all branches (`main` ×4, renovate branches, and PR #1078) with:

```
failed to push registry.cn-shanghai.aliyuncs.com/ahoo/cosid-proxy:<tag>:
denied: unknown manifest class for application/vnd.oci.empty.v1+json
```

## Root cause

`docker/build-push-action@v7` enables **provenance attestations by default** on GitHub-hosted runners. The attestation is pushed as an OCI referrer manifest; DockerHub and GHCR accept it, but **Aliyun ACR does not support OCI attestation manifests** and rejects the push. Since the build pushes to all three registries in one step, the Aliyun rejection fails the whole job.

## Changes

- `docker-deploy.yml`: add `provenance: false` and `sbom: false` to the `Build and push` step. The repo does not consume build attestations anywhere, so disabling them globally costs nothing.

## Testing

- [x] RED: documented failures on every branch (e.g. [main run](https://github.com/Ahoo-Wang/CosId/actions/runs/31952417760), PR #1078 runs)
- [x] GREEN: [run 31955879669](https://github.com/Ahoo-Wang/CosId/actions/runs/31955879669) on this branch completes successfully — images pushed to DockerHub, GHCR, and Aliyun ACR
