### PR TITLE
chore(release): bump version to 3.2.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ org.gradle.parallel=true
 org.gradle.jvmargs=-Xmx2g -Dfile.encoding=UTF-8
 
 group=me.ahoo.cosid
-version=3.2.0
+version=3.2.1
 description=Universal, flexible, high-performance distributed ID generator.
 website=https://github.com/Ahoo-Wang/CosId
 issues=https://github.com/Ahoo-Wang/CosId/issues


### PR DESCRIPTION
## Summary

Bump `version=3.2.0` → `3.2.1` (patch — fix-only release, following the repo's patch convention for fix cycles).

## What's in 3.2.1

- #1078 — correctness fixes from full-module code review (all developed test-first):
  - `fix(sharding)`: `ModCycle` range-sharding node-size overflow (empty-result / `NegativeArraySizeException` on large spans)
  - `fix(proxy-server)`: segment distributor cache self-heals after server restart
  - `fix(snowflake)`: `SafeJavaScriptSnowflakeId.ofMillisecond` millisecond-epoch mismatch
  - `fix(starter)`: `CosIdEndpoint.remove` NPE on unknown generator
- #1079 — CI: disable build attestations for Aliyun ACR push (no library changes)

## Notable behavior changes

- proxy-server `nextMaxId` for a never-created name now succeeds starting from offset 0 instead of returning 500.
- `SafeJavaScriptSnowflakeId.ofMillisecond(machineId)` generates IDs of a different (correct) magnitude — relevant to anyone persisting parsed states across the upgrade.

Publishing will be triggered by creating the `v3.2.1` GitHub release after this merges.
