### PR TITLE
fix(skills): correct inaccurate APIs, properties, and guidance in agent skills

### DIFF
--- a/skills/cosid-manual-integration/SKILL.md
+++ b/skills/cosid-manual-integration/SKILL.md
@@ -19,7 +19,7 @@ Use this skill when CosId must be configured with code instead of `cosid-spring-
 
 CosId provides three main ID generation strategies:
 
-1. **SnowflakeId** - 64-bit time-sortable IDs (timestamp + machineId + sequence)
+1. **SnowflakeId** - 63-bit time-sortable IDs (timestamp + machineId + sequence; the sign bit is reserved)
    - `MillisecondSnowflakeId` - millisecond precision, 41-bit timestamp, 10-bit machine, 12-bit sequence
    - `SecondSnowflakeId` - second precision, 31-bit timestamp, 10-bit machine, 22-bit sequence
    - `SafeJavaScriptSnowflakeId` - wrapper constraining to 53 bits for JS compatibility
@@ -108,13 +108,13 @@ Wrap with the clock-sync variant when system clock drift is a production concern
 | timestampBit | 41 (ms) / 31 (s) | Bits for timestamp component |
 | machineBit | 10 | Bits for machine ID (max 1024 machines) |
 | sequenceBit | 12 (ms) / 22 (s) | IDs per time unit per machine |
-| clockSync | true | Enable clock backwards synchronization |
+| clock sync | wrapper | Wrap with `ClockSyncSnowflakeId` in production (not a config switch) |
 
 ## Common Pitfalls
 
 - **Clock backwards**: Always use `ClockSyncSnowflakeId` wrapper in production
 - **Machine ID overflow**: With 10 bits, max 1024 instances per namespace
-- **Sequence exhaustion**: High throughput may need `SecondSnowflakeId` (4M/s/machine) over millisecond variant (4K/s/machine)
+- **Sequence exhaustion**: The default millisecond layout caps at 4096 IDs per millisecond per machine (~4.096M/s); generation spins into the next millisecond rather than failing. For higher sustained ceilings reallocate bits (larger `sequenceBit`); the second-based layout (`SecondSnowflakeId`, 22-bit sequence) instead allows a full ~4.19M-ID burst within a single second without inter-millisecond spinning
 - **JavaScript safety**: Use `SafeJavaScriptSnowflakeId` if IDs go to frontend
 - **Lifecycle leaks**: Close distributor clients and background workers when the application shuts down
 - **State loss**: Persist machine state when restart stability matters

--- a/skills/cosid-sharding/SKILL.md
+++ b/skills/cosid-sharding/SKILL.md
@@ -44,6 +44,10 @@ Distributes numeric IDs across nodes using `value % divisor`. Best for uniform d
 
 Use `ModCycle` when the sharding key is already numeric and the desired distribution is even across a fixed number of tables or databases.
 
+**Constraints:**
+- Sharding values must be non-negative (SnowflakeId and SegmentId IDs are non-negative); a negative value yields a negative modulo remainder and throws `ArrayIndexOutOfBoundsException` today.
+- Range queries resolve by span: any span covering at least `divisor` values returns all nodes. "Unbounded" ranges such as `Range.closed(0L, Long.MAX_VALUE)` route to all nodes (overflow-safe since 3.2.1).
+
 ### Usage
 
 ```java
@@ -94,10 +98,11 @@ import me.ahoo.cosid.sharding.IntervalTimeline;
 import me.ahoo.cosid.sharding.IntervalStep;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.time.temporal.ChronoUnit;
 import com.google.common.collect.Range;
 
 // Daily sharding for 2024
-IntervalTimeline timeline = new IntervalTimeline(
+IntervalTimeline<LocalDateTime> timeline = new IntervalTimeline<>(
     "t_order_",                                                    // logic name prefix
     Range.closed(
         LocalDateTime.of(2024, 1, 1, 0, 0),
@@ -181,17 +186,18 @@ rules:
 
 ## SnowflakeLocalDateTimeConvertor
 
-Converts SnowflakeId values to LocalDateTime for time-based sharding using SnowflakeId as the sharding key:
+Converts SnowflakeId values to LocalDateTime for time-based sharding using SnowflakeId as the sharding key. It wraps a `SnowflakeIdStateParser` (built from the generator, so epoch and bit layout stay aligned) and accepts either a numeric ID or a Radix62 string:
 
 ```java
 import me.ahoo.cosid.sharding.SnowflakeLocalDateTimeConvertor;
+import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
 
 SnowflakeLocalDateTimeConvertor convertor = new SnowflakeLocalDateTimeConvertor(
-    epoch, timestampBit  // from your SnowflakeId configuration
+    SnowflakeIdStateParser.of(snowflakeId)  // your configured SnowflakeId
 );
 
-// Convert a SnowflakeId to LocalDateTime
-LocalDateTime time = convertor.convert(snowflakeId);
+// Convert a SnowflakeId (Long or Radix62 String) to LocalDateTime
+LocalDateTime time = convertor.toLocalDateTime(snowflakeId.generate());
 ```
 
 This enables using SnowflakeId-based IDs with IntervalTimeline sharding without a separate timestamp column.
@@ -230,6 +236,7 @@ Range queries are often repeated (e.g., querying "last 7 days" across many reque
 Use a small routing matrix before finalizing a rule:
 
 - One exact key routes to exactly one expected node.
+- Sharding keys are non-negative for `ModCycle`; test with real generated IDs, not hand-picked negative values.
 - An `IN` query routes to the union of expected nodes.
 - A range query covers all boundary nodes and no unrelated nodes when possible.
 - Values outside an `IntervalTimeline` effective range fail intentionally.

--- a/skills/cosid-spring-boot/SKILL.md
+++ b/skills/cosid-spring-boot/SKILL.md
@@ -136,6 +136,8 @@ cosid:
     enabled: true
     distributor:
       type: jdbc
+      jdbc:
+        enable-auto-init-cosid-machine-table: true  # auto-create cosid_machine (default false)
   segment:
     enabled: true
     mode: chain
@@ -146,7 +148,7 @@ cosid:
         enable-auto-init-id-segment: true
 ```
 
-This auto-creates the `cosid` table and segment rows. The table schema:
+This auto-creates the `cosid`/`cosid_machine` tables and segment rows. Note: if you register your own `JdbcMachineIdInitializer` bean, the machine-table auto-init flag is silently bypassed (`@ConditionalOnMissingBean` back-off) — perform the DDL yourself in that case. The segment table schema:
 
 ```sql
 CREATE TABLE IF NOT EXISTS cosid (
@@ -338,10 +340,13 @@ public class Order {
 
 ### SnowflakeId State Parsing
 
-Parse snowflake IDs back into their components:
+Parse snowflake IDs back into their components via the state parser (the `SnowflakeId` interface has no `getStateParser()` — build one from the generator):
 
 ```java
-SnowflakeIdState state = snowflakeId.getStateParser().parse(id);
+import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
+
+SnowflakeIdStateParser parser = SnowflakeIdStateParser.of(snowflakeId);
+SnowflakeIdState state = parser.parse(id);
 // state.getTimestamp(), state.getMachineId(), state.getSequence()
 ```
 
@@ -355,7 +360,7 @@ cosid:
     provider:
       short_lived_id:
         timestamp-unit: second  # use seconds instead of milliseconds
-        epoch: 1577203200       # custom epoch (2020-01-01)
+        epoch: 1577203200       # default COSID_EPOCH in seconds (2019-12-24 16:00 UTC)
         timestamp-bit: 31
         machine-bit: 10
         sequence-bit: 22
@@ -435,19 +440,21 @@ cosid:
 
 ## Proxy Mode
 
-For architectures that prefer a dedicated ID service:
+For architectures that prefer a dedicated ID service (cosid-proxy-server). There is no `cosid.proxy.enabled` switch — the proxy backend activates through the `proxy-support` starter capability plus `distributor.type: proxy`:
 
 ```yaml
 # Client side
 cosid:
   proxy:
-    enabled: true
+    host: http://cosid-proxy:8688   # ProxyProperties only has `host`
   segment:
     enabled: true
     mode: chain
     distributor:
       type: proxy
 ```
+
+Since 3.2.1 a proxy-server restart self-heals: `nextMaxId` rebuilds the in-memory distributor cache lazily from the backing store, so already-running clients recover without a restart.
 
 ## Actuator / Monitoring
 

--- a/skills/cosid-strategy-guide/SKILL.md
+++ b/skills/cosid-strategy-guide/SKILL.md
@@ -76,7 +76,7 @@ Generates 63-bit `long` IDs composed of timestamp, machine ID, and sequence.
 | 1 bit unused | 41 bits timestamp | 10 bits machineId | 12 bits sequence |
 ```
 
-- **41-bit timestamp** — ~69 years from epoch (default epoch: 2020-01-01)
+- **41-bit timestamp** — ~69 years from epoch (default epoch `COSID_EPOCH`: 2019-12-24 16:00 UTC, i.e. `1577203200000` ms / `1577203200` s)
 - **10-bit machineId** — up to 1024 instances
 - **12-bit sequence** — 4096 IDs per millisecond
 
@@ -88,7 +88,7 @@ cosid:
     provider:
       second_based:
         timestamp-unit: second
-        epoch: 1577203200      # 2020-01-01 as Unix seconds
+        epoch: 1577203200      # COSID_EPOCH as Unix seconds (2019-12-24 16:00 UTC)
         timestamp-bit: 31
         machine-bit: 10
         sequence-bit: 22


### PR DESCRIPTION
## Summary

Audited the four agent skills under `skills/` against the 3.2.1 source (every constructor, method, YAML path, enum value, and numeric default was checked against the code) and fixed every claim that did not match. The audit was itself independently re-verified by a second review pass — all corrections were confirmed against source, one quantitatively misleading sentence introduced by the audit was rewritten, and three pre-existing inaccuracies were fixed in the same pass.

## Changes

**Nonexistent APIs (would produce compile errors if a user followed them):**
- `SnowflakeLocalDateTimeConvertor`: documented `(epoch, timestampBit)` constructor and `.convert()` never existed → real API is `new SnowflakeLocalDateTimeConvertor(SnowflakeIdStateParser.of(snowflakeId))` + `.toLocalDateTime(id)`
- `snowflakeId.getStateParser()` does not exist on the `SnowflakeId` interface → `SnowflakeIdStateParser.of(snowflakeId).parse(id)`

**Nonexistent / misdocumented configuration:**
- `cosid.proxy.enabled` does not exist (`ProxyProperties` only has `host`) → proxy activates via the `proxy-support` capability + `distributor.type: proxy`; noted the 3.2.1 server-restart self-heal
- Added `cosid.machine.distributor.jdbc.enable-auto-init-cosid-machine-table` (default `false`) with the caveat that registering your own `JdbcMachineIdInitializer` bean bypasses the flag

**Fact corrections:**
- Default epoch is **2019-12-24 16:00 UTC** (`COSID_EPOCH` = 1577203200000 ms / 1577203200 s), not 2020-01-01 (three mentions)
- Sequence exhaustion: ms layout caps at 4096/ms (~4.096M/s) and spins to the next ms rather than failing; the second-based layout's real benefit is a full ~4.19M burst within one second, not a higher sustained ceiling
- Snowflake IDs are 63-bit (sign bit reserved), not 64-bit; dropped the nonexistent `clockSync` config parameter (it is a wrapper class, not a switch)
- `ModCycle`: documented the non-negative sharding-value constraint (negative values throw `ArrayIndexOutOfBoundsException` today) and range-span semantics (span ≥ divisor → all nodes, overflow-safe since 3.2.1)

**Example hygiene:** added the missing `ChronoUnit` import and generics to the `IntervalTimeline` example.

## Testing

- [x] Every changed claim verified against source by the audit, then independently re-verified by a dedicated code-review pass (0 Critical findings; both Important findings addressed in this PR)
- [x] No code changes — skills are agent-facing documentation only
