### PR TITLE
chore(skills): bump ahoo-cosid-skills plugin version to 0.0.4

### DIFF
--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -3,6 +3,7 @@
   "plugins": [
     {
       "name": "ahoo-cosid-skills",
+      "version": "0.0.4",
       "description": "CosId skills for choosing and integrating high-performance distributed ID generators, Spring Boot auto-configuration, machine ID distributors, and ShardingSphere sharding.",
       "skills": {
         "include": [


### PR DESCRIPTION
## Summary

Declare `version: 0.0.4` in `skills/plugins.json` so the [skills marketplace](https://github.com/Ahoo-Wang/skills) generates a 0.0.4 distribution of `ahoo-cosid-skills` containing the accuracy fixes from #1084 (currently shipping as 0.0.3 via the marketplace default version).

One-line metadata change; no skill content changes.