### PR TITLE
fix: upgrade coapi to 2.2.0 and adapt proxy placeholder tests

### DIFF
--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdProxyMachineIdDistributorAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdProxyMachineIdDistributorAutoConfigurationTest.java
@@ -26,11 +26,14 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 class CosIdProxyMachineIdDistributorAutoConfigurationTest {
+    private static final String COAP_PROXY_HOST = "cosid.proxy.host=http://localhost:8688";
+
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(CosIdProxyMachineIdDistributorAutoConfiguration.class))
         .withBean(MachineClient.class, () -> mock(MachineClient.class))
         .withBean(MachineStateStorage.class, () -> MachineStateStorage.IN_MEMORY)
-        .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT);
+        .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT)
+        .withPropertyValues(COAP_PROXY_HOST);
 
     @Test
     void createsProxyMachineIdDistributorWhenTypeIsProxy() {
@@ -85,6 +88,7 @@ class CosIdProxyMachineIdDistributorAutoConfigurationTest {
             .withConfiguration(AutoConfigurations.of(CosIdProxyMachineIdDistributorAutoConfiguration.class))
             .withBean(MachineStateStorage.class, () -> MachineStateStorage.IN_MEMORY)
             .withBean(ClockBackwardsSynchronizer.class, () -> ClockBackwardsSynchronizer.DEFAULT)
+            .withPropertyValues(COAP_PROXY_HOST)
             .withPropertyValues(ConditionalOnCosIdMachineEnabled.ENABLED_KEY + "=true")
             .withPropertyValues(MachineProperties.Distributor.TYPE + "=proxy")
             .run(context -> assertThat(hasCauseMessage(context.getStartupFailure(), "RestClient$Builder"))

--- a/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdProxySegmentAutoConfigurationTest.java
+++ b/cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdProxySegmentAutoConfigurationTest.java
@@ -24,9 +24,12 @@ import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 
 class CosIdProxySegmentAutoConfigurationTest {
+    private static final String COAP_PROXY_HOST = "cosid.proxy.host=http://localhost:8688";
+
     private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(AutoConfigurations.of(CosIdProxySegmentAutoConfiguration.class))
-        .withBean(SegmentClient.class, () -> mock(SegmentClient.class));
+        .withBean(SegmentClient.class, () -> mock(SegmentClient.class))
+        .withPropertyValues(COAP_PROXY_HOST);
 
     @Test
     void createsProxySegmentDistributorFactoryWhenTypeIsProxy() {
@@ -79,6 +82,7 @@ class CosIdProxySegmentAutoConfigurationTest {
     void failsFastWhenCoApiRestClientBuilderIsMissing() {
         new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(CosIdProxySegmentAutoConfiguration.class))
+            .withPropertyValues(COAP_PROXY_HOST)
             .withPropertyValues(ConditionalOnCosIdSegmentEnabled.ENABLED_KEY + "=true")
             .withPropertyValues(SegmentIdProperties.Distributor.TYPE + "=proxy")
             .run(context -> assertThat(hasCauseMessage(context.getStartupFailure(), "RestClient$Builder"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 spring-boot = "4.1.0"
 spring-cloud = "2025.1.2"
 jspecify = "1.0.1"
-coapi = "2.1.0"
+coapi = "2.2.0"
 testcontainers = "2.0.5"
 guava = "33.6.0-jre"
 mybatis = "3.5.19"
@@ -48,4 +48,3 @@ test-retry = { id = "org.gradle.test-retry", version.ref = "test-retry" }
 publish = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "publish-plugin" }
 jmh = { id = "me.champeau.jmh", version.ref = "jmh-plugin" }
 spotbugs = { id = "com.github.spotbugs", version.ref = "spotbugs" }
-


### PR DESCRIPTION
## 变更说明

### 背景
本次调整对应 PR #1083 的依赖升级（coapi 从 2.1.0 升级到 2.2.0），并处理该版本引入的必填占位符语义变化导致的启动行为差异。

### 改动内容
- `gradle/libs.versions.toml`
  - `coapi` 版本升级为 `2.2.0`。
- `cosid-spring-boot-starter` 代理相关自动配置测试补充 `cosid.proxy.host` 配置：
  - `cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/segment/CosIdProxySegmentAutoConfigurationTest.java`
  - `cosid-spring-boot-starter/src/test/java/me/ahoo/cosid/spring/boot/starter/machine/CosIdProxyMachineIdDistributorAutoConfigurationTest.java`

### 处理原因
`coapi 2.2.0` 对 `${...}` 占位符解析改为必填检查（fail-fast），若未配置 `cosid.proxy.host`，`@CoApi(baseUrl = "${cosid.proxy.host}")` 会在上下文启动阶段报错。
本次补充测试属性，保证测试聚焦于自动配置行为本身（如缺失 `RestClient.Builder` 的失败分支），而非被新版本占位符行为所干扰。

### 验证
已执行提交与推送；建议执行：
- `./gradlew cosid-spring-boot-starter:test --tests "me.ahoo.cosid.spring.boot.starter.segment.CosIdProxySegmentAutoConfigurationTest" --tests "me.ahoo.cosid.spring.boot.starter.machine.CosIdProxyMachineIdDistributorAutoConfigurationTest"`
- `./gradlew cosid-spring-boot-starter:check`

### 相关
- 关联 PR：#1083
