### PR TITLE
fix(skills): improve accuracy and safety

### DIFF
--- a/skills/cosid-manual-integration/SKILL.md
+++ b/skills/cosid-manual-integration/SKILL.md
@@ -1,142 +1,125 @@
 ---
 name: cosid-manual-integration
-description: Manually integrate CosId into Java or Kotlin applications without Spring Boot auto-configuration. Use when the user needs programmatic setup for SnowflakeId, SegmentId, SegmentChainId, CosIdGenerator, machine ID distribution, custom IdConverter wiring, non-Spring environments, library/framework integration, or production-safe generator lifecycle management.
+description: Integrate CosId programmatically into Java or Kotlin applications without Spring Boot auto-configuration. Use for direct construction of SnowflakeId, CosIdGenerator, DefaultSegmentId, or SegmentChainId; machine-ID allocation and guarding; backend distributor factories; lifecycle ownership; custom IdConverter wiring; tests; or integration into another framework. Do not use for cosid-spring-boot-starter YAML or feature capabilities.
 ---
 
-# CosId Manual Integration Skill
+# Integrate CosId Programmatically
 
-Use this skill when CosId must be configured with code instead of `cosid-spring-boot-starter`.
+Provide code that compiles against the user's CosId version. Prefer direct constructors for fixed local inputs and backend factories for distributed state.
 
 ## Workflow
 
-1. Identify the generator strategy. Use `$cosid-strategy-guide` first if the user has not chosen one.
-2. Identify the coordination mechanism: manual machine ID, StatefulSet ordinal, Redis, JDBC, MongoDB, ZooKeeper, or proxy.
-3. Show the minimal constructor/wiring path for the chosen generator.
-4. Include lifecycle handling for distributors, guard/heartbeat, prefetch workers, and state storage when relevant.
-5. Add a small verification example: uniqueness, monotonicity, parser behavior, or restart behavior.
+1. Confirm the target version and chosen strategy. Use `$cosid-strategy-guide` only when the strategy is undecided.
+2. Identify the uniqueness authority: fixed machine ID, StatefulSet ordinal, distributed machine-ID backend, or segment backend.
+3. Construct the smallest generator that satisfies the requirement.
+4. Own every created client, guarder, executor, and distributor for its full lifecycle.
+5. Add one focused check for uniqueness, local monotonicity, parsing, restart, or clock rollback.
 
-## Core APIs
+When a CosId checkout is available, verify signatures in `cosid-core/src/main/java/me/ahoo/cosid/` and use existing backend factories and tests as examples. Do not copy older README snippets without checking the current source.
 
-CosId provides three main ID generation strategies:
+## SnowflakeId with a Fixed Machine ID
 
-1. **SnowflakeId** - 63-bit time-sortable IDs (timestamp + machineId + sequence; the sign bit is reserved)
-   - `MillisecondSnowflakeId` - millisecond precision, 41-bit timestamp, 10-bit machine, 12-bit sequence
-   - `SecondSnowflakeId` - second precision, 31-bit timestamp, 10-bit machine, 22-bit sequence
-   - `SafeJavaScriptSnowflakeId` - wrapper constraining to 53 bits for JS compatibility
-
-2. **SegmentId** - Batch ID allocation for high throughput
-   - `SegmentChainId` - lock-free chain with prefetch worker (~127M+ ops/s)
-   - Requires a `SegmentIdDistributor` (Redis, JDBC, ZooKeeper, MongoDB)
-
-3. **CosIdGenerator** - Large-scale cluster string ID generator (~15M+ ops/s)
-   - Uses Radix62 encoding for compact string IDs
-   - Requires `MachineIdDistributor` for machine ID allocation (same as SnowflakeId)
-   - Supports much larger instance counts than SnowflakeId (not constrained by 63-bit long format)
-
-## Machine ID Allocation
-
-For SnowflakeId, each instance needs a unique machineId. Options:
-
-- **Manual**: Set machineId directly (0-1023 for default 10-bit)
-- **Redis**: `SpringRedisMachineIdDistributor` - uses Redis for coordination
-- **JDBC**: `JdbcMachineIdDistributor` - uses database table
-- **ZooKeeper**: `ZookeeperMachineIdDistributor` - uses ZK nodes
-- **MongoDB**: `MongoMachineIdDistributor` - uses MongoDB collection
-- **StatefulSet**: Kubernetes StatefulSet ordinal as machineId
-
-Always define the namespace and instance identity deliberately. For production, prefer a distributor that can guard ownership and reclaim expired machine IDs.
-
-## SnowflakeId Configuration Pattern
+Use this only when deployment automation guarantees a unique value per live instance.
 
 ```java
-// 1. Create a backend-specific MachineIdDistributor
-MachineIdDistributor distributor = createMachineIdDistributor();
-
-// 2. Allocate machine ID
-int machineBit = 10;
-InstanceId instanceId = InstanceId.of("order-service-0", true);
-MachineState machineState = distributor.distribute(
-    "my-namespace",
-    machineBit,
-    instanceId,
-    Duration.ofSeconds(10)
+int machineId = 1;
+SnowflakeId idGenerator = new ClockSyncSnowflakeId(
+    new MillisecondSnowflakeId(machineId)
 );
-int machineId = machineState.getMachineId();
-
-// 3. Create SnowflakeId
-SnowflakeId snowflakeId = new MillisecondSnowflakeId(machineId);
-
-// 4. Wrap with clock sync for safety
-SnowflakeId safeId = new ClockSyncSnowflakeId(snowflakeId);
-
-// 5. Generate IDs
-long id = safeId.generate();
-```
-
-If the user has fixed deployment slots, use `ManualMachineIdDistributor` or directly provide the machine ID, but warn that duplicate machine IDs can create duplicate IDs.
-
-## Segment Configuration Pattern
-
-Use `SegmentId` or `SegmentChainId` when monotonic IDs and batch allocation are more important than time-encoded IDs.
-
-```java
-IdSegmentDistributor distributor = createIdSegmentDistributor("order_id", 100);
-SegmentChainId idGenerator = new SegmentChainId(distributor);
 
 long id = idGenerator.generate();
-String text = idGenerator.generateAsString();
 ```
 
-For `SegmentChainId`, ensure the prefetch worker lifecycle is owned by the application and is closed during shutdown if the concrete setup exposes close/shutdown behavior.
+Use `SecondSnowflakeId` only for a deliberate second-based bit layout. Use `SafeJavaScriptSnowflakeId.ofMillisecond(machineId)` when a numeric ID must stay within JavaScript's safe integer range; otherwise serialize ordinary IDs as strings.
 
-## CosIdGenerator Pattern
+## Distributed Machine-ID Allocation
 
-Use `CosIdGenerator` when callers need compact string IDs rather than `long` IDs.
+Create the backend-specific `MachineIdDistributor`, then allocate with the exact namespace, machine bits, instance identity, and lease:
 
 ```java
-CosIdGenerator generator = new Radix62CosIdGenerator(machineId);
+static SnowflakeId createSnowflake(MachineIdDistributor distributor) {
+    String namespace = "order-service";
+    InstanceId instanceId = InstanceId.of("10.0.0.12:8080", false);
+    Duration lease = Duration.ofMinutes(5);
+
+    MachineState state = distributor.distribute(
+        namespace,
+        10,
+        instanceId,
+        lease
+    );
+    return new ClockSyncSnowflakeId(
+        new MillisecondSnowflakeId(state.getMachineId())
+    );
+}
+```
+
+The snippet shows allocation, not heartbeat ownership. For expiring distributed leases, wrap allocation with `GuardDistribute`, run a `DefaultMachineIdGuarder`, stop it during shutdown, and call `distributor.revert(namespace, instanceId)` after stopping the guarder. Gate readiness and generation on `guarder.hasFailure()` because the guarder records heartbeat failure but does not stop ID generation. Shut down any `ScheduledExecutorService` created by the application after stopping the guarder. Pass `stable: true` only for a stable deployment identity such as a StatefulSet slot; stable instances retain their machine-ID claim instead of being recycled by the lease cutoff. Use local state storage only when the filesystem follows that stable identity; it helps reclaim the previous machine ID and prevents clock regression after restart.
+
+For a fixed manual ID through the distributor API, use the real constructor:
+
+```java
+MachineIdDistributor distributor = new ManualMachineIdDistributor(
+    1,
+    MachineStateStorage.LOCAL,
+    ClockBackwardsSynchronizer.DEFAULT
+);
+```
+
+## Segment Generators
+
+Obtain the distributor from the selected backend's `IdSegmentDistributorFactory` and keep the namespace/name/offset/step definition explicit:
+
+```java
+static SegmentId createSegment(IdSegmentDistributorFactory distributorFactory) {
+    IdSegmentDistributorDefinition definition =
+        new IdSegmentDistributorDefinition("order-service", "order", 0, 100);
+    IdSegmentDistributor distributor = distributorFactory.create(definition);
+    return new SegmentChainId(distributor);
+}
+```
+
+Use `new DefaultSegmentId(distributor)` instead when synchronous rollover is preferred. `SegmentChainId` uses `PrefetchWorkerExecutorService.DEFAULT`, which installs a JVM shutdown hook; if the application supplies its own executor, shut that executor down explicitly.
+
+Segment IDs are monotonic only within one generator. Distributed ranges provide global uniqueness and trend ordering, not strict global generation-time order.
+
+## String Conversion
+
+Wrap `long` generators with the matching string decorator instead of reimplementing generation:
+
+```java
+IdConverter converter = new PrefixIdConverter(
+    "ORD-",
+    Radix62IdConverter.PAD_START
+);
+SnowflakeId stringSnowflake = new StringSnowflakeId(snowflakeId, converter);
+SegmentId stringSegment = new StringSegmentId(segmentId, converter);
+```
+
+Call `generateAsString()` on the wrapper and test `converter.asLong()` when round-trip parsing is required. `CosIdGenerator` does not support `IdConverter`; select or implement its `CosIdIdStateParser` instead.
+
+## CosIdGenerator
+
+`CosIdGenerator` produces strings; calling `generate()` throws `UnsupportedOperationException`.
+
+```java
+CosIdGenerator generator = new ClockSyncCosIdGenerator(
+    new Radix62CosIdGenerator(machineId)
+);
 String id = generator.generateAsString();
 ```
 
-Wrap with the clock-sync variant when system clock drift is a production concern.
+Allocate `machineId` with the same uniqueness and lifecycle rules as SnowflakeId.
 
-## Key Parameters
+## Boundaries and Checks
 
-| Parameter | Default | Description |
-|-----------|---------|-------------|
-| epoch | 2019-12-24 | Custom epoch for timestamp calculation |
-| timestampBit | 41 (ms) / 31 (s) | Bits for timestamp component |
-| machineBit | 10 | Bits for machine ID (max 1024 machines) |
-| sequenceBit | 12 (ms) / 22 (s) | IDs per time unit per machine |
-| clock sync | wrapper | Wrap with `ClockSyncSnowflakeId` in production (not a config switch) |
+- Keep one namespace per independent allocation domain and one stable instance identity per deployment slot.
+- Reject machine IDs outside the configured bit range before starting traffic.
+- Do not claim global monotonicity for segment generators or global total order for clock-based generators.
+- Keep custom epoch, timestamp unit, bit layout, parser, and sharding converter aligned.
+- Close backend clients created by the application. Do not close shared framework clients that the application does not own.
+- Test with at least two simulated instances when correctness depends on distributed uniqueness.
 
-## Common Pitfalls
+## Response Contract
 
-- **Clock backwards**: Always use `ClockSyncSnowflakeId` wrapper in production
-- **Machine ID overflow**: With 10 bits, max 1024 instances per namespace
-- **Sequence exhaustion**: The default millisecond layout caps at 4096 IDs per millisecond per machine (~4.096M/s); generation spins into the next millisecond rather than failing. For higher sustained ceilings reallocate bits (larger `sequenceBit`); the second-based layout (`SecondSnowflakeId`, 22-bit sequence) instead allows a full ~4.19M-ID burst within a single second without inter-millisecond spinning
-- **JavaScript safety**: Use `SafeJavaScriptSnowflakeId` if IDs go to frontend
-- **Lifecycle leaks**: Close distributor clients and background workers when the application shuts down
-- **State loss**: Persist machine state when restart stability matters
-
-## Testing Configuration
-
-For tests, use `ManualMachineIdDistributor` with fixed machine IDs:
-
-```java
-MachineIdDistributor distributor = new ManualMachineIdDistributor(1);
-```
-
-Add tests for the property that matters in the user's case:
-
-- Uniqueness across concurrent generation
-- Local monotonicity for SegmentId/SegmentChainId
-- Time parser correctness for SnowflakeId
-- JavaScript-safe range or string conversion
-- Machine ID conflict behavior when manual IDs are used
-
-## Source Pointers
-
-- Source: `cosid-core/src/main/java/me/ahoo/cosid/`
-- Examples: `examples/` directory
-- Spring Boot starter: `cosid-spring-boot-starter/` for auto-config reference
+Return the required module dependencies, exact imports and constructors, lifecycle ownership, one runnable check, and no unrelated Spring Boot configuration.

--- a/skills/cosid-sharding/SKILL.md
+++ b/skills/cosid-sharding/SKILL.md
@@ -1,78 +1,84 @@
 ---
 name: cosid-sharding
-description: Design and configure CosId sharding algorithms for database sharding and ShardingSphere. Use when the user mentions table or database sharding, ShardingSphere COSID_MOD or COSID_INTERVAL rules, modulo sharding, date/time interval sharding, range routing, SnowflakeId timestamp extraction, ModCycle, IntervalTimeline, CachedSharding, PreciseSharding, RangeSharding, or SnowflakeLocalDateTimeConvertor.
+description: Design, implement, and validate CosId database sharding with core ModCycle, IntervalTimeline, CachedSharding, and SnowflakeLocalDateTimeConvertor APIs or ShardingSphere COSID_MOD, COSID_INTERVAL, and COSID_INTERVAL_SNOWFLAKE algorithms. Use for modulo routing, date/time partitions, Snowflake timestamp routing, exact/IN/range behavior, effective nodes, suffix naming, or routing tests. Do not use for choosing an ID generator unless sharding is the primary concern.
 ---
 
-# CosId Sharding Algorithms
+# Design CosId Sharding
 
-Use this skill to choose, configure, and validate CosId sharding behavior.
+Treat core Java sharding APIs and ShardingSphere configuration as separate integration surfaces. Verify the target CosId and ShardingSphere versions before copying property names.
 
 ## Workflow
 
-1. Identify the sharding key type: numeric ID, SnowflakeId, `LocalDateTime`, or an existing timestamp column.
-2. Choose the algorithm: `ModCycle` for uniform numeric distribution, `IntervalTimeline` for time ranges, or `CachedSharding` to cache repeated range routing.
-3. Confirm both precise and range queries. ShardingSphere routes `=`, `IN`, and range predicates differently.
-4. Define effective nodes and bounds explicitly. For interval sharding, include lower/upper datetime bounds and suffix format.
-5. Provide a minimal Java or ShardingSphere YAML example and a routing test.
+1. Identify the sharding key type and every query operator that must route: exact, `IN`, and range.
+2. Define physical nodes, naming, bounds, and future partition provisioning before selecting an algorithm.
+3. Choose `ModCycle` for fixed-count numeric distribution or `IntervalTimeline` for time partitions.
+4. Add Snowflake conversion only when the ID layout is known and aligned with the parser.
+5. Build a routing matrix that covers boundaries, out-of-range values, and full-range queries.
 
-## Sharding Algorithm Types
+## Core Algorithms
 
-| Algorithm | Class | Best For |
+| API | Use | Important behavior |
 |---|---|---|
-| **Modulo (ModCycle)** | `ModCycle<T>` | Uniform distribution, numeric IDs |
-| **Interval Timeline** | `IntervalTimeline` | Date-based partitioning, time-series data |
-| **Cached Sharding** | `CachedSharding<T>` | Wraps any algorithm to cache range lookups |
+| `ModCycle<T>` | Fixed number of numeric nodes | Exact route is `value % divisor`; current implementation requires non-negative values |
+| `IntervalTimeline` | Bounded `LocalDateTime` partitions | Exact values outside the effective interval throw `IllegalArgumentException` |
+| `SnowflakeLocalDateTimeConvertor` | Convert Snowflake `Long` or radix-62 `String` to time | Parser must match the generator epoch and bit layout |
+| `CachedSharding<T>` | Reuse identical range results | `@Beta` and backed by an unbounded cache; use only for demonstrably low-cardinality repeated ranges |
 
-## Architecture
-
-The sharding hierarchy:
-
-```
-Sharding<T>              (combines precise + range)
-├── PreciseSharding<T>   (single value → node)
-└── RangeSharding<T>     (value range → collection of nodes)
-
-Implementations:
-├── ModCycle<T>          (modulo-based, numeric IDs)
-├── IntervalTimeline     (time-based intervals)
-└── CachedSharding<T>    (caching decorator)
-```
-
-## ModCycle - Modulo Sharding
-
-Distributes numeric IDs across nodes using `value % divisor`. Best for uniform distribution when using SnowflakeId or SegmentId.
-
-Use `ModCycle` when the sharding key is already numeric and the desired distribution is even across a fixed number of tables or databases.
-
-**Constraints:**
-- Sharding values must be non-negative (SnowflakeId and SegmentId IDs are non-negative); a negative value yields a negative modulo remainder and throws `ArrayIndexOutOfBoundsException` today.
-- Range queries resolve by span: any span covering at least `divisor` values returns all nodes. "Unbounded" ranges such as `Range.closed(0L, Long.MAX_VALUE)` route to all nodes (overflow-safe since 3.2.1).
-
-### Usage
+### Modulo Example
 
 ```java
-import me.ahoo.cosid.sharding.ModCycle;
+ModCycle<Long> sharding = new ModCycle<>(4, "t_order_");
 
-// Shard across 4 nodes: table_0, table_1, table_2, table_3
-ModCycle<Long> sharding = new ModCycle<>(4, "table_");
-
-// Precise sharding
-String node = sharding.sharding(42L);  // → "table_2"
-
-// Range sharding
-Range<Long> range = Range.closed(1L, 10L);
-Collection<String> nodes = sharding.sharding(range);  // all 4 nodes
+String exact = sharding.sharding(42L); // t_order_2
+Collection<String> range = sharding.sharding(Range.closed(1L, 10L));
 ```
 
-### ShardingSphere Integration
+A range spanning at least `divisor` consecutive values routes to every node. Open and unbounded ranges must be included in tests. Do not pass negative values unless the implementation has been changed to use floor-mod semantics.
+
+### Interval Example
+
+```java
+IntervalTimeline timeline = new IntervalTimeline(
+    "t_order_",
+    Range.closed(
+        LocalDateTime.of(2024, 1, 1, 0, 0),
+        LocalDateTime.of(2024, 12, 31, 23, 59, 59)
+    ),
+    IntervalStep.of(ChronoUnit.MONTHS),
+    DateTimeFormatter.ofPattern("yyyyMM")
+);
+
+String exact = timeline.sharding(LocalDateTime.of(2024, 3, 15, 10, 30));
+Collection<String> range = timeline.sharding(Range.closed(
+    LocalDateTime.of(2024, 3, 1, 0, 0),
+    LocalDateTime.of(2024, 4, 30, 23, 59, 59)
+));
+```
+
+Supported `IntervalStep` units are years, months, days, hours, minutes, and seconds. Ensure the suffix format is unique for the selected step.
+
+### Snowflake Conversion
+
+```java
+SnowflakeIdStateParser parser = SnowflakeIdStateParser.of(snowflakeId);
+SnowflakeLocalDateTimeConvertor convertor =
+    new SnowflakeLocalDateTimeConvertor(parser);
+
+LocalDateTime time = convertor.toLocalDateTime(snowflakeId.generate());
+```
+
+The converter accepts only `Long` and radix-62 `String` values. It is not a general converter for arbitrary numeric types or custom string encodings.
+
+## ShardingSphere
+
+CosId algorithm availability and properties vary by ShardingSphere release. Inspect the target artifact or official source before emitting a type. When `COSID_MOD` is available, its divisor property is named `mod`, not `divisor`:
 
 ```yaml
-# ShardingSphere YAML configuration
 rules:
   - !SHARDING
     tables:
       t_order:
-        actualDataNodes: ds_${0..1}.t_order_${0..3}
+        actualDataNodes: ds_0.t_order_$->{0..3}
         tableStrategy:
           standard:
             shardingColumn: order_id
@@ -81,181 +87,33 @@ rules:
       t_order_mod:
         type: COSID_MOD
         props:
-          divisor: 4
+          mod: 4
           logic-name-prefix: t_order_
 ```
 
-## IntervalTimeline - Time-Based Sharding
+For ordinary time keys, configure an available `COSID_INTERVAL` implementation with `datetime-lower`, `datetime-upper`, `sharding-suffix-pattern`, `datetime-interval-unit`, and `datetime-interval-amount`.
 
-Distributes data across time-based intervals. Each interval maps to a specific node named with a formatted date suffix.
+Handle Snowflake interval routing by version:
 
-Use `IntervalTimeline` when table names encode time periods such as day, month, or hour. It is also appropriate when a SnowflakeId can be converted back into event time.
+- Prefer the core API shown above when application code owns routing; `SnowflakeIdStateParser.of(snowflakeId)` follows the actual generator's epoch and bit layout.
+- In Apache ShardingSphere 5.4.0, `COSID_INTERVAL_SNOWFLAKE` reads only `epoch` and `zone-id` and hardcodes the default millisecond Snowflake layout. Use it only for that layout; `id-name` does not align a custom generator.
+- For every other ShardingSphere release, verify that the CosId plugin and requested properties exist. Do not emit `COSID_INTERVAL_SNOWFLAKE` merely because an older document lists it.
+- For a custom bit layout, use a version-verified integration that resolves the actual generator or a minimal `StandardShardingAlgorithm` that delegates to `SnowflakeIdStateParser` and `IntervalTimeline`.
 
-### Usage
+Ensure `actualDataNodes` enumerates only valid physical suffixes; a daily numeric range such as `${20240101..20241231}` also generates impossible dates and must not be used.
 
-```java
-import me.ahoo.cosid.sharding.IntervalTimeline;
-import me.ahoo.cosid.sharding.IntervalStep;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
-import java.time.temporal.ChronoUnit;
-import com.google.common.collect.Range;
+## Validation Matrix
 
-// Daily sharding for 2024
-IntervalTimeline<LocalDateTime> timeline = new IntervalTimeline<>(
-    "t_order_",                                                    // logic name prefix
-    Range.closed(
-        LocalDateTime.of(2024, 1, 1, 0, 0),
-        LocalDateTime.of(2024, 12, 31, 23, 59, 59)
-    ),
-    IntervalStep.of(ChronoUnit.DAYS),                              // daily intervals
-    DateTimeFormatter.ofPattern("yyyyMMdd")                         // suffix format
-);
+Test at least:
 
-// Precise: which table holds data for 2024-03-15?
-String node = timeline.sharding(LocalDateTime.of(2024, 3, 15, 10, 30));
-// → "t_order_20240315"
+- first and last exact key for every boundary node;
+- one `IN` set spanning multiple nodes;
+- closed, open, unbounded, empty, and out-of-domain ranges;
+- negative input rejection for `ModCycle`;
+- an interval transition such as month-end or year-end;
+- Snowflake values generated with the actual epoch, unit, and bit layout;
+- equality between algorithm effective nodes and provisioned physical nodes.
 
-// Range: which tables cover March 2024?
-Range<LocalDateTime> marchRange = Range.closed(
-    LocalDateTime.of(2024, 3, 1, 0, 0),
-    LocalDateTime.of(2024, 3, 31, 23, 59, 59)
-);
-Collection<String> nodes = timeline.sharding(marchRange);
-// → ["t_order_20240301", "t_order_20240302", ..., "t_order_20240331"]
-```
+## Response Contract
 
-### Interval Step Options
-
-```java
-// Yearly intervals
-IntervalStep.of(ChronoUnit.YEARS)
-
-// Monthly intervals
-IntervalStep.of(ChronoUnit.MONTHS)
-
-// Daily intervals
-IntervalStep.of(ChronoUnit.DAYS)
-
-// Hourly intervals
-IntervalStep.of(ChronoUnit.HOURS)
-
-// Custom: every 3 months
-IntervalStep.of(ChronoUnit.MONTHS, 3)
-```
-
-### Common Suffix Formatters
-
-```java
-// Yearly: t_order_2024, t_order_2025
-DateTimeFormatter.ofPattern("yyyy")
-
-// Monthly: t_order_202401, t_order_202402
-DateTimeFormatter.ofPattern("yyyyMM")
-
-// Daily: t_order_20240315
-DateTimeFormatter.ofPattern("yyyyMMdd")
-
-// Hourly: t_order_2024031514
-DateTimeFormatter.ofPattern("yyyyMMddHH")
-```
-
-### ShardingSphere Integration for Interval Sharding
-
-```yaml
-rules:
-  - !SHARDING
-    tables:
-      t_order:
-        actualDataNodes: ds_0.t_order_${20240101..20241231}
-        tableStrategy:
-          standard:
-            shardingColumn: create_time
-            shardingAlgorithmName: t_order_interval
-    shardingAlgorithms:
-      t_order_interval:
-        type: COSID_INTERVAL
-        props:
-          logic-name-prefix: t_order_
-          datetime-lower: "2024-01-01 00:00:00"
-          datetime-upper: "2024-12-31 23:59:59"
-          sharding-suffix-pattern: yyyyMMdd
-          datetime-interval-unit: DAYS
-          datetime-interval-amount: 1
-```
-
-## SnowflakeLocalDateTimeConvertor
-
-Converts SnowflakeId values to LocalDateTime for time-based sharding using SnowflakeId as the sharding key. It wraps a `SnowflakeIdStateParser` (built from the generator, so epoch and bit layout stay aligned) and accepts either a numeric ID or a Radix62 string:
-
-```java
-import me.ahoo.cosid.sharding.SnowflakeLocalDateTimeConvertor;
-import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
-
-SnowflakeLocalDateTimeConvertor convertor = new SnowflakeLocalDateTimeConvertor(
-    SnowflakeIdStateParser.of(snowflakeId)  // your configured SnowflakeId
-);
-
-// Convert a SnowflakeId (Long or Radix62 String) to LocalDateTime
-LocalDateTime time = convertor.toLocalDateTime(snowflakeId.generate());
-```
-
-This enables using SnowflakeId-based IDs with IntervalTimeline sharding without a separate timestamp column.
-
-## CachedSharding
-
-Wraps any sharding algorithm to cache range sharding results:
-
-```java
-import me.ahoo.cosid.sharding.CachedSharding;
-
-ModCycle<Long> modSharding = new ModCycle<>(32, "table_");
-CachedSharding<Long> cachedSharding = new CachedSharding<>(modSharding);
-
-// First range query computes and caches
-Collection<String> nodes1 = cachedSharding.sharding(Range.closed(1L, 100L));
-
-// Subsequent identical range queries use cache
-Collection<String> nodes2 = cachedSharding.sharding(Range.closed(1L, 100L));
-```
-
-Range queries are often repeated (e.g., querying "last 7 days" across many requests), so caching avoids redundant computation.
-
-## Choosing a Sharding Strategy
-
-| Scenario | Algorithm | Why |
-|---|---|---|
-| Uniform numeric ID distribution | ModCycle | Simple, even distribution |
-| Date-based table partitioning | IntervalTimeline | Maps time ranges to tables |
-| SnowflakeId as sharding key | IntervalTimeline + SnowflakeLocalDateTimeConvertor | Extract timestamp from ID |
-| High QPS range queries | CachedSharding + any | Cache avoids recomputation |
-| Auto-increment / SegmentId as key | ModCycle | Even distribution of monotonic IDs |
-
-## Validation Checklist
-
-Use a small routing matrix before finalizing a rule:
-
-- One exact key routes to exactly one expected node.
-- Sharding keys are non-negative for `ModCycle`; test with real generated IDs, not hand-picked negative values.
-- An `IN` query routes to the union of expected nodes.
-- A range query covers all boundary nodes and no unrelated nodes when possible.
-- Values outside an `IntervalTimeline` effective range fail intentionally.
-- Snowflake timestamp extraction uses the same epoch and timestamp bits as the generator.
-- The ShardingSphere `actualDataNodes` expression matches every possible CosId effective node.
-
-## Key Design Principles
-
-1. **Precise + Range**: Every algorithm supports both single-value and range sharding. ShardingSphere uses precise for `=` and `IN`, and range for `BETWEEN`, `>`, `<`.
-2. **Effective nodes**: `getEffectiveNodes()` returns all possible target nodes. This is used by ShardingSphere for routing optimization.
-3. **Thread safety**: The `Sharding` interface is annotated `@ThreadSafe`; implementations follow that contract, but not every concrete class repeats the annotation.
-4. **Interval bounds**: `IntervalTimeline` requires an explicit effective time range. Values outside this range throw `IllegalArgumentException`.
-5. **Generator alignment**: When the sharding key is a CosId-generated ID, keep the generator epoch, timestamp unit, and converter settings aligned with the sharding rule.
-
-## Response Template
-
-When answering a sharding request, include:
-
-1. The selected algorithm and why it fits the sharding key.
-2. The expected table/database naming pattern.
-3. A concise Java or ShardingSphere YAML example.
-4. A routing test matrix for exact, `IN`, and range queries.
+Return the chosen algorithm, physical naming model, minimal Java or version-matched ShardingSphere configuration, and the routing matrix. Call out any partition provisioning or cache-growth risk explicitly.

--- a/skills/cosid-sharding/agents/openai.yaml
+++ b/skills/cosid-sharding/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "CosId Sharding"
-  short_description: "Design CosId ShardingSphere rules"
-  default_prompt: "Use $cosid-sharding to design CosId sharding rules for my database tables."
+  short_description: "Design CosId core and ShardingSphere rules"
+  default_prompt: "Use $cosid-sharding to design and validate CosId core or ShardingSphere routing."

--- a/skills/cosid-spring-boot/SKILL.md
+++ b/skills/cosid-spring-boot/SKILL.md
@@ -1,91 +1,56 @@
 ---
 name: cosid-spring-boot
-description: Configure CosId in Spring Boot applications with cosid-spring-boot-starter. Use when the user works with application.yml, Gradle or Maven dependencies, starter feature variants, Redis/JDBC/MongoDB/ZooKeeper/proxy distributors, SnowflakeId, SegmentId, SegmentChainId, CosIdGenerator, @CosId, IdGeneratorProvider, ID converters, machine guarder settings, clock-backwards synchronization, or Actuator endpoints in a Spring Boot service.
+description: Configure and troubleshoot CosId in Spring Boot with cosid-spring-boot-starter. Use for Gradle feature capabilities or Maven modules, application.yml, Redis/JDBC/MongoDB/ZooKeeper/proxy distributors, SnowflakeId, CosIdGenerator, DefaultSegmentId, SegmentChainId, shared or named generators, converters, @CosId persistence integration, machine guarding, clock rollback, JDBC initialization, or Actuator. Do not use for programmatic non-Spring wiring.
 ---
 
-# CosId Spring Boot Integration
+# Configure CosId for Spring Boot
 
-CosId is a universal, flexible, high-performance distributed ID generator for Java 17+. The Spring Boot starter (`cosid-spring-boot-starter`) provides auto-configuration for all ID generation strategies.
+Produce the smallest configuration for one chosen strategy and backend. Do not enable every generator in a single template.
 
 ## Workflow
 
-1. Confirm the user's Spring Boot and CosId major versions. CosId 2.x targets Spring Boot 3.x and Java 17; CosId 3.x targets Spring Boot 4.x and Java 17.
-2. Choose the ID strategy. Use `$cosid-strategy-guide` first when the user has not chosen between SnowflakeId, SegmentId, SegmentChainId, and CosIdGenerator.
-3. Select the distributor and starter capability needed by the deployment: Redis, JDBC, MongoDB, ZooKeeper, proxy, manual, or StatefulSet.
-4. Provide the smallest working YAML for the selected strategy and backend.
-5. Show how the application consumes the generator: shared bean, named provider, or `@CosId`.
-6. Add validation guidance for uniqueness, ordering, machine ID ownership, segment allocation, and Actuator visibility.
+1. Confirm compatibility: CosId 3.x aligns with Spring Boot 4.x; CosId 2.x aligns with Spring Boot 3.x; both require Java 17.
+2. Confirm the generator strategy. Use `$cosid-strategy-guide` only when it is undecided.
+3. Add the starter capability or Maven backend modules required by that strategy.
+4. Emit minimal YAML and one consumption pattern.
+5. Verify context startup, generator registration, uniqueness, and the selected backend's state.
 
-## Dependency Setup
+In a CosId checkout, treat these as the source of truth:
 
-Add the BOM and starter to your Gradle build. When you need a distributor backend, select the corresponding Gradle feature capability:
+- capabilities: `cosid-spring-boot-starter/build.gradle.kts`;
+- property names/defaults: `cosid-spring-boot-starter/src/main/java/.../*Properties.java`;
+- binding examples: corresponding `*PropertiesTest.java` files;
+- bean names and provider behavior: `SegmentIdBeanRegistrar` and `SnowflakeIdBeanRegistrar`.
 
-```groovy
+## Dependencies
+
+Use the BOM and repeat the starter dependency for every required Gradle capability:
+
+```kotlin
 dependencies {
-    implementation platform("me.ahoo.cosid:cosid-bom:${cosidVersion}")
-
-    // Redis backend. Replace the capability with jdbc-support, mongo-support,
-    // zookeeper-support, proxy-support, actuator-support, etc. as needed.
+    implementation(platform("me.ahoo.cosid:cosid-bom:$cosidVersion"))
     implementation("me.ahoo.cosid:cosid-spring-boot-starter") {
         capabilities {
             requireCapability("me.ahoo.cosid:spring-redis-support")
         }
     }
+    implementation("me.ahoo.cosid:cosid-spring-boot-starter") {
+        capabilities {
+            requireCapability("me.ahoo.cosid:mybatis-support")
+        }
+    }
 }
 ```
 
-For Maven, import the BOM and add the starter plus the backend module explicitly:
+Available capabilities include `spring-redis-support`, `jdbc-support`, `mongo-support`, `zookeeper-support`, `proxy-support`, `mybatis-support`, `data-jdbc-support`, and `actuator-support`. Add only those used by the application, with one dependency block per capability.
 
-```xml
-<dependencyManagement>
-    <dependencies>
-        <dependency>
-            <groupId>me.ahoo.cosid</groupId>
-            <artifactId>cosid-bom</artifactId>
-            <version>${cosid.version}</version>
-            <type>pom</type>
-            <scope>import</scope>
-        </dependency>
-    </dependencies>
-</dependencyManagement>
+For Maven, import `cosid-bom`, add `cosid-spring-boot-starter`, and add the concrete backend/integration module such as `cosid-spring-redis`, `cosid-jdbc`, `cosid-mongo`, `cosid-zookeeper`, `cosid-mybatis`, or `cosid-spring-data-jdbc`. Also include the application framework/runtime dependency required to create its client, such as the Redis, JDBC, or MongoDB Spring Boot starter.
 
-<dependencies>
-    <dependency>
-        <groupId>me.ahoo.cosid</groupId>
-        <artifactId>cosid-spring-boot-starter</artifactId>
-    </dependency>
-    <!-- Redis backend. Use cosid-jdbc, cosid-mongo, or cosid-zookeeper for other backends. -->
-    <dependency>
-        <groupId>me.ahoo.cosid</groupId>
-        <artifactId>cosid-spring-redis</artifactId>
-    </dependency>
-</dependencies>
-```
+## Minimal Configurations
 
-## Choosing an ID Strategy
+### Snowflake with a Fixed Machine ID
 
-There are 4 ID generation strategies in CosId. The right choice depends on your requirements:
-
-| Strategy | Throughput | Trend | Best For |
-|---|---|---|---|
-| **CosIdGenerator** | ~15M+/s | Time-ordered | Standalone apps, no distributed coordination needed |
-| **SnowflakeId** | ~4M+/s | Time-ordered | Distributed systems needing sortable IDs, typical microservices |
-| **SegmentId** | ~20M+/s | Monotonic | High-throughput with simple coordination, trend-increasing |
-| **SegmentChainId** | ~127M+/s | Monotonic | Maximum throughput, lock-free prefetching, production workloads |
-
-### Decision Guide
-
-- **Need maximum performance and have Redis/JDBC available?** → SegmentChainId (default segment mode)
-- **Need time-sortable IDs across machines?** → SnowflakeId
-- **Need compact string IDs or a large machine-ID design space?** → CosIdGenerator
-- **Database-friendly monotonic IDs?** → SegmentId or SegmentChainId
-- **Need only strategy selection?** → Use `$cosid-strategy-guide` before writing YAML
-
-## Configuration Templates
-
-### Full-featured Redis Setup (Most Common)
-
-This is the most typical production configuration with both SnowflakeId and SegmentChainId:
+Use only when deployment assigns a unique machine ID to every live instance.
 
 ```yaml
 cosid:
@@ -93,51 +58,41 @@ cosid:
   machine:
     enabled: true
     distributor:
-      type: redis
-  generator:
-    enabled: true
+      type: manual
+      manual:
+        machine-id: ${COSID_MACHINE_ID}
   snowflake:
     enabled: true
-    share:
-      enabled: true  # shared SnowflakeId as default IdGenerator
-    provider:
-      order_id:
-        converter:
-          type: radix
-          prefix: ORDER
-          radix:
-            char-size: 11
-            pad-start: true
-  segment:
-    enabled: true
-    mode: chain  # CHAIN = SegmentChainId (recommended), SEGMENT = basic SegmentId
-    distributor:
-      type: redis
-    share:
-      enabled: true  # shared SegmentChainId as default StringIdGenerator
-    provider:
-      user_id:
-        step: 100
-        converter:
-          type: to_string
-          to-string:
-            char-size: 10
-            pad-start: true
 ```
 
-### JDBC Backend Setup
+For Redis/JDBC/MongoDB/ZooKeeper/proxy allocation, replace the distributor type and add its capability. Keep `machine.enabled: true` for SnowflakeId and CosIdGenerator.
 
-For environments where only a relational database is available:
+### SegmentChainId with Redis
+
+Segment generators do not require machine-ID configuration.
 
 ```yaml
 cosid:
   namespace: ${spring.application.name}
-  machine:
+  segment:
     enabled: true
+    mode: chain
     distributor:
-      type: jdbc
-      jdbc:
-        enable-auto-init-cosid-machine-table: true  # auto-create cosid_machine (default false)
+      type: redis
+    share:
+      enabled: false
+    provider:
+      order:
+        step: 100
+```
+
+Use `mode: segment` for `DefaultSegmentId`. The default mode is `chain`; spelling it out makes intent visible.
+
+### SegmentChainId with JDBC
+
+```yaml
+cosid:
+  namespace: ${spring.application.name}
   segment:
     enabled: true
     mode: chain
@@ -148,351 +103,79 @@ cosid:
         enable-auto-init-id-segment: true
 ```
 
-This auto-creates the `cosid`/`cosid_machine` tables and segment rows. Note: if you register your own `JdbcMachineIdInitializer` bean, the machine-table auto-init flag is silently bypassed (`@ConditionalOnMissingBean` back-off) — perform the DDL yourself in that case. The segment table schema:
+Automatic DDL is convenient for controlled environments. Prefer migrations when schema ownership matters. Machine allocation through JDBC has a separate property: `cosid.machine.distributor.jdbc.enable-auto-init-cosid-machine-table`. A custom `JdbcMachineIdInitializer` bean disables that auto-initializer through conditional back-off.
 
-```sql
-CREATE TABLE IF NOT EXISTS cosid (
-    name VARCHAR(100) NOT NULL,
-    last_max_id BIGINT NOT NULL DEFAULT 0,
-    last_fetch_time BIGINT NOT NULL DEFAULT 0,
-    PRIMARY KEY (name)
-);
-```
-
-### MongoDB Backend Setup
+### CosIdGenerator
 
 ```yaml
 cosid:
   namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: mongo
-      mongo:
-        database: cosid_db
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: mongo
-      mongo:
-        database: cosid_db
-```
-
-### ZooKeeper Backend Setup
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: zookeeper
-  snowflake:
-    enabled: true
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: zookeeper
-```
-
-### Manual Machine ID (for fixed-instance deployments)
-
-When you have a known, fixed set of instances:
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: manual
-      manual:
-        machine-id: 1  # must be unique per instance
-  snowflake:
-    enabled: true
-```
-
-### Kubernetes StatefulSet
-
-For StatefulSet deployments, the pod ordinal is used as the machine ID:
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: stateful_set
-  snowflake:
-    enabled: true
-```
-
-## ID Converter Types
-
-Converters transform `long` IDs into `String` representations. Configure via `converter` in each provider definition.
-
-| Type | Description | Example Output |
-|---|---|---|
-| `radix` (default) | Base62 encoding (0-9, A-Z, a-z) | `ORDER-0Gjk3R0p` |
-| `radix36` | Base36 encoding (0-9, A-Z) | `BIZ-00001234` |
-| `to_string` | Plain decimal string with padding | `0000000001` |
-| `snowflake_friendly` | Human-readable snowflake timestamp | `20240101-120000-1-0-0` |
-| `custom` | Your own `IdConverter` implementation | — |
-
-### Converter Configuration Examples
-
-```yaml
-# Short alphanumeric ID (radix62)
-converter:
-  type: radix
-  prefix: ORDER
-  radix:
-    char-size: 11
-    pad-start: true
-
-# Numeric string with date prefix
-converter:
-  type: to_string
-  prefix: BIZ-
-  date-prefix:
-    enabled: true
-    pattern: yyMMdd
-  to-string:
-    char-size: 10
-    pad-start: true
-
-# Human-readable snowflake
-converter:
-  type: snowflake_friendly
-  friendly:
-    pad-start: true
-
-# With group-based prefix (for date-partitioned segments)
-converter:
-  type: to_string
-  prefix: BIZ-
-  group-prefix:
-    enabled: true
-  to-string:
-    char-size: 8
-    pad-start: true
-```
-
-## Using the ID Generator in Code
-
-### Injecting the Shared IdGenerator
-
-When `share.enabled: true`, a default `IdGenerator` bean is registered:
-
-```java
-@Service
-public class OrderService {
-    private final IdGenerator idGenerator;
-    
-    public OrderService(IdGenerator idGenerator) {
-        this.idGenerator = idGenerator;
-    }
-    
-    public Order createOrder() {
-        long orderId = idGenerator.generate();
-        String orderIdStr = idGenerator.generateAsString();
-        // ...
-    }
-}
-```
-
-### Injecting Named Generators
-
-Named generators from `provider` are available via `IdGeneratorProvider`:
-
-```java
-@Service
-public class UserService {
-    private final IdGenerator userIdGenerator;
-    
-    public UserService(IdGeneratorProvider provider) {
-        this.userIdGenerator = provider.get("user_id");
-    }
-    
-    public User createUser() {
-        long userId = userIdGenerator.generate();
-        // ...
-    }
-}
-```
-
-### Using @CosId Annotation
-
-The `@CosId` annotation auto-assigns IDs to entity fields:
-
-```java
-import me.ahoo.cosid.annotation.CosId;
-
-public class Order {
-    @CosId("order_id")
-    private Long id;
-    
-    // getters/setters
-}
-```
-
-### SnowflakeId State Parsing
-
-Parse snowflake IDs back into their components via the state parser (the `SnowflakeId` interface has no `getStateParser()` — build one from the generator):
-
-```java
-import me.ahoo.cosid.snowflake.SnowflakeIdStateParser;
-
-SnowflakeIdStateParser parser = SnowflakeIdStateParser.of(snowflakeId);
-SnowflakeIdState state = parser.parse(id);
-// state.getTimestamp(), state.getMachineId(), state.getSequence()
-```
-
-## SnowflakeId Bit Layout Customization
-
-The default MillisecondSnowflakeId uses 41-bit timestamp, 10-bit machineId, 12-bit sequence. Customize per-provider:
-
-```yaml
-cosid:
-  snowflake:
-    provider:
-      short_lived_id:
-        timestamp-unit: second  # use seconds instead of milliseconds
-        epoch: 1577203200       # default COSID_EPOCH in seconds (2019-12-24 16:00 UTC)
-        timestamp-bit: 31
-        machine-bit: 10
-        sequence-bit: 22
-```
-
-Bit allocation must satisfy: `timestampBit + machineBit + sequenceBit = 63`.
-
-## Segment Grouping (Date-partitioned IDs)
-
-Group segments by time period for date-based ID sequences:
-
-```yaml
-cosid:
-  segment:
-    provider:
-      daily_order:
-        group:
-          by: year_month_day  # or year, year_month
-          pattern: yyMMdd
-        converter:
-          type: to_string
-          prefix: BIZ-
-          group-prefix:
-            enabled: true
-          to-string:
-            char-size: 8
-            pad-start: true
-```
-
-## Machine ID Management
-
-### Guarder Configuration
-
-The guarder keeps machine ID registrations alive via heartbeat:
-
-```yaml
-cosid:
   machine:
     enabled: true
     distributor:
       type: redis
-    guarder:
-      enabled: true
-      safe-guard-duration: 5m  # how long the guard is valid
-      initial-delay: 1s
-      delay: 10s
-```
-
-### Clock Backwards Synchronization
-
-Handle clock drift in distributed environments:
-
-```yaml
-cosid:
-  machine:
+  generator:
     enabled: true
-    clock-backwards:
-      spin-threshold: 100
-      broken-threshold: 2000
+    type: radix62
 ```
 
-- `spin-threshold`: Small clock drift is handled by spinning/waiting
-- `broken-threshold`: Large clock drift throws `ClockTooManyBackwardsException`
+Inject it as `CosIdGenerator` and call `generateAsString()`. Its `generate()` method is unsupported.
 
-### State Storage
+## Consume Generators Safely
 
-Machine state persists locally to survive restarts:
+Named segment and Snowflake generators are registered in `IdGeneratorProvider` and as singleton beans named `<name>SegmentId` or `<name>SnowflakeId`:
 
-```yaml
-cosid:
-  machine:
-    enabled: true
-    state-storage:
-      local:
-        state-location: .cosid-machine-state  # default path
+```java
+IdGenerator orderId = idGeneratorProvider.getRequired("order");
+long id = orderId.generate();
 ```
 
-## Proxy Mode
+`IdGeneratorProvider.get(name)` returns `Optional<IdGenerator>`; use `getRequired(name)` when absence is an error.
 
-For architectures that prefer a dedicated ID service (cosid-proxy-server). There is no `cosid.proxy.enabled` switch — the proxy backend activates through the `proxy-support` starter capability plus `distributor.type: proxy`:
+The shared definition is enabled by default under `__share__`. If Snowflake and Segment are both enabled, they compete for the same shared provider entry. Disable one share or use named definitions and qualified concrete beans; do not rely on registration order.
 
-```yaml
-# Client side
-cosid:
-  proxy:
-    host: http://cosid-proxy:8688   # ProxyProperties only has `host`
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: proxy
+## `@CosId` Boundary
+
+The annotation alone does not assign IDs. Enable a persistence integration that invokes the accessor registry, such as `mybatis-support` for inserts or `data-jdbc-support` for Spring Data JDBC before-convert callbacks, then register the referenced generator:
+
+```java
+public class Order {
+    @CosId("order")
+    private Long id;
+}
 ```
 
-Since 3.2.1 a proxy-server restart self-heals: `nextMaxId` rebuilds the in-memory distributor cache lazily from the backing store, so already-running clients recover without a restart.
+Do not promise annotation support for an ORM or persistence path without verifying that its CosId integration is present.
 
-## Actuator / Monitoring
+## Operational Rules
 
-Enable Spring Boot Actuator endpoints for monitoring:
+- Machine IDs must be unique within a namespace and within the configured machine-bit range.
+- The machine guarder is enabled by default. Keep lease duration longer than heartbeat delay and expose failures through health monitoring when Actuator is used.
+- Snowflake definitions default to clock sync. Custom second-based definitions require an epoch in seconds; millisecond definitions require milliseconds.
+- Snowflake timestamp, machine, and sequence bits must total 63.
+- Proxy activation uses `proxy-support`, `cosid.proxy.host`, and `distributor.type: proxy`; there is no `cosid.proxy.enabled` property.
+- Actuator endpoints require `actuator-support` and explicit endpoint exposure. The `cosid` endpoint includes a delete operation that removes a registered generator; for status-only access on Spring Boot 4, set `management.endpoint.cosid.access: read-only` and protect the management endpoint with HTTP authorization or network isolation. On Spring Boot versions without endpoint access levels, deny non-read methods or do not expose it.
+- Converter output must be tested for prefix, padding, radix, maximum length, and target-column capacity.
+
+For a Spring Boot 4 status-only endpoint, start with:
 
 ```yaml
 management:
   endpoints:
+    access:
+      default: none
     web:
       exposure:
-        include:
-          - cosid
-          - cosidGenerator
-          - cosidStringGenerator
-          - health
+        include: cosid
   endpoint:
-    health:
-      show-details: always
+    cosid:
+      access: read-only
 ```
 
-The `cosid` endpoint shows all registered ID generators and their stats.
+## Validation
 
-## Validation Checklist
+Run one focused Spring Boot context test with the selected capability and properties. Assert the expected bean/provider name, generate concurrent IDs, and inspect the backend row/key/lease or Actuator state. Integration tests require the actual Redis, JDBC, MongoDB, ZooKeeper, or proxy service.
 
-- Run a focused Spring Boot test that loads the application context with the chosen backend capability.
-- Generate IDs concurrently and assert uniqueness.
-- For SnowflakeId, verify machine ID allocation and clock-backwards settings.
-- For SegmentId/SegmentChainId, verify the segment distributor initializes the `cosid` table or backend state.
-- For converters, assert the expected prefix, padding, radix, and string length.
-- For shared beans, assert `IdGenerator` or `StringIdGenerator` resolves to the intended provider.
-- For production services, expose and inspect the CosId Actuator endpoint when actuator support is enabled.
+## Response Contract
 
-## Response Template
-
-When answering a Spring Boot integration request, include:
-
-1. Dependency coordinates and the required backend capability.
-2. Minimal `application.yml` for the selected generator.
-3. Code snippet for injection or `@CosId`.
-4. Operational notes for machine ID, clock, state storage, and monitoring.
-5. A small test or verification command the user can run.
+Return version alignment, exact dependency capability/modules, minimal YAML for one strategy, one correct consumption example, one operational warning, and one runnable verification.

--- a/skills/cosid-strategy-guide/SKILL.md
+++ b/skills/cosid-strategy-guide/SKILL.md
@@ -1,283 +1,67 @@
 ---
 name: cosid-strategy-guide
-description: Choose the right CosId ID generation strategy for Java distributed systems. Use when the user compares CosIdGenerator, SnowflakeId, SegmentId, or SegmentChainId; asks which generator to use; or evaluates ID type, ordering, throughput, clock sensitivity, machine ID allocation, JavaScript-safe IDs, coordination backends, or production tradeoffs.
+description: Choose a CosId ID generation strategy for Java distributed systems. Use when the user compares CosIdGenerator, SnowflakeId, SegmentId, or SegmentChainId, or asks about ID representation, ordering guarantees, clock sensitivity, JavaScript safety, coordination backends, gaps, throughput, or production tradeoffs. Do not use for implementation-only requests after the strategy is already fixed; use cosid-spring-boot or cosid-manual-integration instead.
 ---
 
-# CosId ID Strategy Selection Guide
+# Choose a CosId Strategy
 
-Use this skill to turn requirements into a concrete CosId generator recommendation.
+Recommend one strategy from explicit requirements. Do not default to the largest benchmark number.
 
 ## Workflow
 
-1. Identify the constraints: required ID type (`long`, `String`, or both), ordering semantics, peak QPS, cluster size, JavaScript exposure, acceptable gaps, available infrastructure, and whether IDs must encode time.
-2. Recommend one primary strategy and, when useful, one fallback.
-3. Explain the operational cost: clock behavior, external coordination, machine ID lifecycle, segment gaps, restart behavior, and tuning knobs.
-4. Hand off to `$cosid-spring-boot` for Spring Boot YAML or `$cosid-manual-integration` for programmatic setup.
-5. Include a small configuration sketch only when the user needs implementation detail.
+1. Confirm the target CosId major version. In a CosId checkout, read `gradle.properties`; do not assume the current branch matches the user's application.
+2. Collect the required ID type, ordering scope, peak and burst rate, instance count, JavaScript exposure, acceptable gaps, available infrastructure, and outage behavior.
+3. Recommend one primary strategy. Add a fallback only when a real constraint creates a close tradeoff.
+4. State the operational cost and the exact ordering guarantee.
+5. Hand implementation to `$cosid-spring-boot` or `$cosid-manual-integration`.
 
-## Strategy Comparison
+## Decision Table
 
-| | CosIdGenerator | SnowflakeId | SegmentId | SegmentChainId |
+| Strategy | Output | Ordering | Coordination | Main constraint |
 |---|---|---|---|---|
-| **Throughput** | ~15M+/s | ~4M+/s | ~20M+/s | ~127M+/s |
-| **ID Type** | String only | long + String | long + String | long + String |
-| **Trend** | Time-ordered | Time-ordered | Monotonic increasing | Monotonic increasing |
-| **External Dependency** | MachineIdDistributor | MachineIdDistributor | IdSegmentDistributor | IdSegmentDistributor |
-| **Coordination** | Once at startup | Once at startup | Per segment | Background prefetch |
-| **Clock Sensitive** | Yes | Yes | No | No |
-| **Max Instances** | 2^machineBit | 2^machineBit | Unlimited | Unlimited |
+| `CosIdGenerator` | `String` only | Locally time-ordered; globally affected by clocks | Unique machine ID | Clock-sensitive; `generate()` is unsupported |
+| `SnowflakeId` | `long` and converted `String` | Locally monotonic; globally trend-ordered | Unique machine ID | Clock-sensitive and bounded by bit allocation |
+| `DefaultSegmentId` | `long` and converted `String` | Locally monotonic; globally trend-ordered by allocated ranges | `IdSegmentDistributor` at segment rollover | Allocation can stall or fail when the current segment is exhausted |
+| `SegmentChainId` | `long` and converted `String` | Locally monotonic; globally trend-ordered by allocated ranges | `IdSegmentDistributor` plus background prefetch | More lifecycle work; gaps can grow with prefetched ranges |
+
+Benchmark results are hardware- and workload-specific. Use them only as evidence that a strategy meets a class of demand, then benchmark the selected strategy with realistic concurrency and backend latency.
 
 ## Recommendation Rules
 
-- Use `SegmentChainId` as the default production recommendation when the system can use Redis, JDBC, MongoDB, ZooKeeper, or the proxy distributor and needs high-throughput monotonic IDs.
-- Use `SnowflakeId` when callers need `long` IDs that are roughly time ordered or must be parsed back into timestamp, machine ID, and sequence.
-- Use `SegmentId` when the team wants monotonic IDs with simpler behavior than `SegmentChainId` and can tolerate fetching a new segment synchronously when the current segment is exhausted.
-- Use `CosIdGenerator` when compact `String` IDs are acceptable and the deployment needs a larger design space than the 63-bit Snowflake layout.
-- Use manual or StatefulSet machine ID allocation only when instance identities are fixed and operationally controlled.
-- Prefer Redis for low-latency coordination when it already exists; prefer JDBC when the platform already depends on a relational database and wants fewer moving parts.
-- For JavaScript clients, return strings or wrap Snowflake with `SafeJavaScriptSnowflakeId` when numeric precision matters.
+- Choose `SnowflakeId` for a numeric primary key that should roughly encode creation time and continue generating locally after machine-ID allocation.
+- Choose `CosIdGenerator` when callers require compact structured strings and do not need a `long`. Its default 20 machine bits provide a larger instance space than default Snowflake.
+- Choose `DefaultSegmentId` when local monotonicity matters, gaps are acceptable, and synchronous range allocation is operationally simple enough.
+- Choose `SegmentChainId` when distributor latency at rollover matters enough to justify prefetching. Prefetch reduces stalls; it does not make the distributor irrelevant after reserved ranges run out.
+- Return IDs as strings to JavaScript by default. Use `SafeJavaScriptSnowflakeId` only when a numeric JavaScript-safe value is an explicit requirement.
+- Reuse Redis, JDBC, MongoDB, ZooKeeper, or proxy infrastructure already operated by the system. Do not add a backend solely because one benchmark is faster.
+- Use manual or StatefulSet machine IDs only when instance identities and uniqueness are operationally guaranteed.
 
-## Strategy Details
+## Ordering and Availability
 
-### CosIdGenerator: Large-Scale String IDs
+- No listed strategy provides strict global generation-time order across concurrent instances.
+- Snowflake and CosIdGenerator depend on wall clocks; clock-sync wrappers wait for bounded rollback and fail when the configured broken threshold is exceeded.
+- Segment generators allocate disjoint ranges. One instance can emit a higher range while another still emits a lower range.
+- Segment restart or prefetch can leave unused IDs. Increase `step` or prefetch distance only after accepting that gap tradeoff.
+- Manual duplicate machine IDs can produce duplicate Snowflake or CosIdGenerator IDs.
 
-Produces compact string IDs and is useful when a `long` ID format is not required.
+If the requirement is strict global sequencing by request time, say that CosId's distributed generators do not provide it and recommend a serialized authority such as a database sequence or dedicated sequencer.
 
-**When to use:**
-- Large-scale clusters that exceed SnowflakeId's machine bit limit (typically 1024 instances)
-- Need globally unique IDs across a very large number of instances
-- Want compact string IDs (shorter than long-to-string converted SnowflakeIds)
-- Don't need `long` type IDs (only generates String)
+## Stable Facts to Use Carefully
 
-**Tradeoffs:**
-- Cannot generate `long` IDs — only `String` via `generateAsString()`
-- Requires `MachineIdDistributor` for machine ID allocation (same as SnowflakeId)
-- Clock-sensitive (like SnowflakeId)
+- Default millisecond Snowflake layout: 41 timestamp bits, 10 machine bits, 12 sequence bits; the sign bit is reserved.
+- Default second Snowflake layout: 31 timestamp bits, 10 machine bits, 22 sequence bits.
+- Snowflake bit allocation must total 63.
+- Default epoch: `2019-12-24T16:00:00` UTC (`1577203200000` ms or `1577203200` s).
+- Default CosIdGenerator layout is independent of Snowflake: 44 timestamp bits, 20 machine bits, and 16 sequence bits.
 
-**Variants:**
-- `Radix62CosIdGenerator` — Base62 encoding, compact (default)
-- `Radix36CosIdGenerator` — Base36 encoding, uppercase only
-- `FriendlyCosIdGenerator` — Human-readable format
-- `ClockSyncCosIdGenerator` — Wraps any CosIdGenerator with clock sync
+Verify these values against the target version before emitting custom configuration.
 
-### SnowflakeId: Time-Ordered Distributed Long IDs
+## Response Contract
 
-Generates 63-bit `long` IDs composed of timestamp, machine ID, and sequence.
+Include:
 
-**When to use:**
-- Need time-sortable IDs (IDs roughly reflect creation time)
-- Want `long` type IDs for database primary keys
-- Need to parse IDs back into timestamp/machineId/sequence components
-- JavaScript clients need safe IDs (use `SafeJavaScriptSnowflakeId`)
-
-**Bit layout (default MillisecondSnowflakeId):**
-
-```
-| 1 bit unused | 41 bits timestamp | 10 bits machineId | 12 bits sequence |
-```
-
-- **41-bit timestamp** — ~69 years from epoch (default epoch `COSID_EPOCH`: 2019-12-24 16:00 UTC, i.e. `1577203200000` ms / `1577203200` s)
-- **10-bit machineId** — up to 1024 instances
-- **12-bit sequence** — 4096 IDs per millisecond
-
-**Customizing bit layout:**
-
-```yaml
-cosid:
-  snowflake:
-    provider:
-      second_based:
-        timestamp-unit: second
-        epoch: 1577203200      # COSID_EPOCH as Unix seconds (2019-12-24 16:00 UTC)
-        timestamp-bit: 31
-        machine-bit: 10
-        sequence-bit: 22
-```
-
-**Important constraint:** `timestampBit + machineBit + sequenceBit = 63` (63 because the sign bit is reserved).
-
-**Clock backwards handling:** SnowflakeId is sensitive to system clock changes. Use `ClockSyncSnowflakeId` or Spring Boot clock-backwards settings for production:
-- Small drift (< `spinThreshold`): Spin-wait until time catches up
-- Large drift (> `brokenThreshold`): Throw `ClockTooManyBackwardsException`
-
-### SegmentId: Monotonic IDs with Batch Allocation
-
-Allocates IDs in contiguous segments (batches) to reduce network I/O. Each instance gets a range of IDs and serves them locally.
-
-**When to use:**
-- Need monotonic (always increasing) IDs
-- Want database-friendly sequential IDs
-- Simpler than SegmentChainId, good for moderate throughput
-- Don't want to deal with machine ID allocation (not clock-sensitive)
-
-**How it works:**
-
-```
-Instance A: [1-100]   ← allocated from Redis/DB
-Instance B: [101-200] ← allocated from Redis/DB
-
-Instance A serves IDs 1, 2, 3, ..., 100
-When exhausted, allocates next segment [201-300]
-```
-
-**Spring Boot config:**
-
-```yaml
-cosid:
-  segment:
-    enabled: true
-    mode: segment     # basic segment mode
-    distributor:
-      type: redis
-    provider:
-      user_id:
-        step: 100     # segment size (IDs per allocation)
-```
-
-**Tuning the `step` parameter:**
-- Larger step: fewer network calls, but more ID gaps on restart
-- Smaller step: fewer wasted IDs, but more coordination overhead
-- Start with `step: 100` for moderate workloads, increase to `1000+` for high QPS
-
-### SegmentChainId: Maximum Throughput
-
-An enhancement of SegmentId that chains multiple segments with lock-free prefetching. This is the highest-throughput ID generator in CosId.
-
-**When to use:**
-- Production workloads needing maximum throughput (~127M+ IDs/s)
-- Want monotonic IDs without the latency spikes of SegmentId
-- Have Redis, JDBC, MongoDB, or ZooKeeper available
-- The default recommended choice for most production systems
-
-**How it differs from SegmentId:**
-
-SegmentChainId maintains a chain of prefetched segments. A background worker prefetches new segments before the current one is exhausted, so ID generation never blocks waiting for network I/O.
-
-```
-SegmentId:      [current segment] → BLOCK until next segment allocated
-SegmentChainId: [current] → [prefetched] → [prefetched] → (background prefetch)
-```
-
-The prefetch distance adapts dynamically:
-- **High demand** (hungry): Distance doubles (up to 100M)
-- **Low demand** (full): Distance halves (down to `safeDistance`)
-
-## Distributor Backends
-
-Both SegmentId and SegmentChainId require a distributor to coordinate segment allocation. Machine ID allocation (for SnowflakeId/CosIdGenerator) also uses distributors.
-
-| Backend | Segment Distributor | Machine ID Distributor | Best For |
-|---|---|---|---|
-| **Redis** | Yes | Yes | Most common, low latency |
-| **JDBC** | Yes | Yes | When only a database is available |
-| **MongoDB** | Yes | Yes | MongoDB-based infrastructure |
-| **ZooKeeper** | Yes | Yes | Existing ZooKeeper clusters |
-| **Proxy** | Yes | Yes | Dedicated ID service architecture |
-| **Manual** | No | Yes | Fixed instances, known machine IDs |
-| **StatefulSet** | No | Yes | Kubernetes StatefulSet |
-
-## Machine ID Allocation
-
-SnowflakeId and CosIdGenerator require unique machine IDs. The `MachineIdDistributor` allocates and guards these IDs.
-
-### How It Works
-
-1. On startup, an instance requests a machine ID from the distributor
-2. The guarder sends periodic heartbeats to maintain the lease
-3. If an instance dies, its machine ID is released after `safeGuardDuration`
-4. State persists locally to improve restart stability
-
-### Choosing a Machine ID Distributor
-
-- **Redis** (recommended): Fast, atomic allocation, works with existing Redis
-- **JDBC**: Use when you already have a database but no Redis
-- **Manual**: For fixed instances where you assign machine IDs yourself
-- **StatefulSet**: For Kubernetes StatefulSet (uses pod ordinal as machine ID)
-- **ZooKeeper**: For environments already running ZooKeeper
-
-### Machine State Persistence
-
-CosId persists machine state to the local filesystem to improve restart stability. A restarted instance tries to reclaim its previous machine ID before requesting a new one.
-
-```yaml
-cosid:
-  machine:
-    state-storage:
-      local:
-        state-location: .cosid-machine-state  # default
-```
-
-## Common Patterns
-
-### Production Microservice with Redis
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: redis
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: redis
-    share:
-      enabled: true
-    provider:
-      order_id:
-        converter:
-          type: radix
-          prefix: ORD
-  snowflake:
-    enabled: true
-    share:
-      enabled: true
-```
-
-### Database-Only with JDBC
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: jdbc
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: jdbc
-      jdbc:
-        enable-auto-init-cosid-table: true
-        enable-auto-init-id-segment: true
-```
-
-### Kubernetes StatefulSet
-
-```yaml
-cosid:
-  namespace: ${spring.application.name}
-  machine:
-    enabled: true
-    distributor:
-      type: stateful_set
-  snowflake:
-    enabled: true
-  segment:
-    enabled: true
-    mode: chain
-    distributor:
-      type: redis
-```
-
-## Response Template
-
-When answering a strategy question, use this structure:
-
-1. Recommendation: name the generator and why it matches the constraints.
-2. Tradeoffs: call out ordering, throughput, clock sensitivity, coordination, and restart gaps.
-3. Configuration direction: name the distributor backend and whether Spring Boot or manual setup is appropriate.
-4. Validation: suggest a focused test or benchmark for the user's actual throughput and ordering requirement.
+1. one recommendation and the requirements it satisfies;
+2. the precise ordering, gap, and failure semantics;
+3. the machine-ID or segment-distributor choice;
+4. one focused validation or benchmark;
+5. the correct implementation skill for the next step.

--- a/skills/plugins.json
+++ b/skills/plugins.json
@@ -3,7 +3,7 @@
   "plugins": [
     {
       "name": "ahoo-cosid-skills",
-      "version": "0.0.4",
+      "version": "0.0.5",
       "description": "CosId skills for choosing and integrating high-performance distributed ID generators, Spring Boot auto-configuration, machine ID distributors, and ShardingSphere sharding.",
       "skills": {
         "include": [


### PR DESCRIPTION
## Summary

- streamline all four CosId skills and sharpen their trigger boundaries
- correct API, ordering, lifecycle, Spring Boot capability, and ShardingSphere guidance
- document machine-ID guard failure handling and read-only Actuator exposure
- refresh sharding UI metadata and bump the skill plugin to 0.0.5

## Why

The existing skills duplicated volatile configuration and included several inaccurate or unsafe examples. Notably, they overstated global ordering, used stale APIs and ShardingSphere properties, omitted persistence requirements for `@CosId`, and did not call out that the `cosid` Actuator endpoint includes a delete operation.

## Impact

Agents get shorter, source-oriented workflows with explicit version checks, exact lifecycle ownership, and safer defaults. The four skill bodies shrink substantially while covering previously missing converter, multi-capability, and custom Snowflake layout cases.

## Validation

- all four skills pass `quick_validate.py`
- `git diff --check`
- `./gradlew cosid-core:test --tests 'me.ahoo.cosid.snowflake.StringSnowflakeIdTest' --tests 'me.ahoo.cosid.segment.StringSegmentIdTest' --tests 'me.ahoo.cosid.converter.PrefixIdConverterTest'`
- `./gradlew cosid-spring-boot-starter:test --tests 'me.ahoo.cosid.spring.boot.starter.actuate.CosIdEndpointAutoConfigurationTest' --tests 'me.ahoo.cosid.spring.boot.starter.mybatis.CosIdMybatisAutoConfigurationTest'`
- forward-tested strategy, manual integration, Spring Boot, and sharding scenarios