### PR TITLE
docs: fix invalid default value 'fasle' -> 'false'

### DIFF
--- a/document/docs/blog/ShardingSphere-Integration-CosId.md
+++ b/document/docs/blog/ShardingSphere-Integration-CosId.md
@@ -98,7 +98,7 @@ Apache ShardingSphere 是一款开源分布式数据库生态项目，由 JDBC�
 | 名称        | 数据类型     | 说明                                              | 默认值         |
 |-----------|----------|-------------------------------------------------|-------------|
 | id-name   | `String` | `IdGenerator` 的名称（在 `IdGeneratorProvider` 中已注册） | `__share__` |
-| as-string | `String` | 是否生成字符串类型的ID                                    | `fasle`     |
+| as-string | `String` | 是否生成字符串类型的ID                                    | `false`     |
 
 ```yaml
 spring:

--- a/document/docs/config/shardingsphere.md
+++ b/document/docs/config/shardingsphere.md
@@ -11,7 +11,7 @@
 | 名称        | 数据类型     | 说明                                              | 默认值         |
 |-----------|----------|-------------------------------------------------|-------------|
 | id-name   | `String` | `IdGenerator` 的名称（在 `IdGeneratorProvider` 中已注册） | `__share__` |
-| as-string | `String` | 是否生成字符串类型的ID                                    | `fasle`     |
+| as-string | `String` | 是否生成字符串类型的ID                                    | `false`     |
 
 **YAML 配置样例**
 


### PR DESCRIPTION
The ShardingSphere config tables document the default value of `as-string` as `\`fasle\``, which is not a valid boolean literal — a reader copying it would get an invalid config.

Corrected to `\`false\`` in:

- `document/docs/config/shardingsphere.md:14`
- `document/docs/blog/ShardingSphere-Integration-CosId.md:101`

Only the literal value is changed; the surrounding Chinese descriptions are untouched.
