### PR TITLE
fix(renovate): defer dep updates until they pass pnpm minimumReleaseAge cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "commitMessagePrefix": "fix(deps)",
   "commitMessageTopic": "{{depName}}",
   "rangeStrategy": "bump",
+  "minimumReleaseAge": "1 day",
   "lockFileMaintenance": { "enabled": false },
   "prConcurrentLimit": 5,
   "packageRules": [


### PR DESCRIPTION
## Summary

Fixes the Documentation Build and Deploy failure in https://github.com/Ahoo-Wang/CosId/actions/runs/32804783528.

## Root Cause

- pnpm 11 turns on supply-chain protection by default: `minimumReleaseAge=1440` minutes, so `pnpm install` rejects any lockfile entry published less than 24 hours ago.
- Renovate merged `mermaid@11.17.1` (published 2026-08-24T13:04Z) about 14 hours after publication, and the docs workflow triggered on push to `documentation/**` failed with `ERR_PNPM_MINIMUM_RELEASE_AGE_VIOLATION`.

## Changes

- `renovate.json`: add `"minimumReleaseAge": "1 day"` so Renovate only creates update PRs once a release is at least as old as pnpm's cooldown window. This keeps pnpm 11's protection intact instead of disabling it in `pnpm-workspace.yaml`.

## Notes

- The already-merged mermaid bump self-heals: once 11.17.1 is older than 24h (2026-08-25T13:04Z), the nightly scheduled run (`cron: '0 0 * * *'`) deploys successfully; no lockfile rollback is needed.
- Residual risk (accepted): a freshly published *transitive* dependency regenerated into the lockfile by a Renovate update can still trip the pnpm check; such failures also self-heal on the next scheduled run.
- Config validated with `renovate-config-validator` (no findings related to this change; the pre-existing `matchPackagePatterns` migration warning is untouched).

## Testing

- [x] `renovate-config-validator` accepts the config
- [ ] Docs workflow green after merge/nightly run
